### PR TITLE
featured product section refactored && double add section refactored

### DIFF
--- a/src/app/_components/ads.tsx
+++ b/src/app/_components/ads.tsx
@@ -33,9 +33,9 @@ export function Ads({ entities }: { entities: common_HeroEntity[] }) {
             return (
               <div
                 key={e.double?.left?.media?.id}
-                className="flex h-screen w-full flex-col lg:flex-row"
+                className="relative flex h-screen w-full flex-col lg:flex-row"
               >
-                <div className="relative z-0 h-full w-full">
+                <div className="relative h-full w-full">
                   <Image
                     src={e.double?.left?.media?.media?.fullSize?.mediaUrl || ""}
                     alt="ad hero image"
@@ -46,7 +46,7 @@ export function Ads({ entities }: { entities: common_HeroEntity[] }) {
                     fit="cover"
                     // blurHash={media.media?.blurhash}
                   />
-                  <div className="absolute inset-0 z-10 flex flex-col items-center justify-center space-y-6">
+                  <div className="absolute inset-0 z-20 flex flex-col items-center justify-center space-y-6">
                     <Text variant="uppercase" className="text-white">
                       {e.double?.left?.headline}
                     </Text>
@@ -63,7 +63,7 @@ export function Ads({ entities }: { entities: common_HeroEntity[] }) {
                 </div>
                 <div
                   key={e.double?.right?.media?.id}
-                  className="relative z-0 h-full w-full"
+                  className="relative h-full w-full"
                 >
                   <Image
                     src={
@@ -76,7 +76,7 @@ export function Ads({ entities }: { entities: common_HeroEntity[] }) {
                     )}
                     fit="cover"
                   />
-                  <div className="absolute inset-0 z-10 flex flex-col items-center justify-center space-y-6">
+                  <div className="absolute inset-0 z-20 flex flex-col items-center justify-center space-y-6">
                     <Text variant="uppercase" className="text-white">
                       {e.double?.right?.headline}
                     </Text>
@@ -91,6 +91,7 @@ export function Ads({ entities }: { entities: common_HeroEntity[] }) {
                     </Button>
                   </div>
                 </div>
+                <div className="absolute inset-0 z-[1] h-screen bg-black opacity-40"></div>
               </div>
             );
           case "HERO_TYPE_FEATURED_PRODUCTS":
@@ -107,7 +108,7 @@ export function Ads({ entities }: { entities: common_HeroEntity[] }) {
                     </Link>
                   </Button>
                 </div>
-                <div className="flex gap-10 overflow-x-scroll">
+                <div className="no-scroll-bar flex gap-10 overflow-x-scroll">
                   {e.featuredProducts?.products?.map((p) => (
                     <ProductItem className="w-[282px]" key={p.id} product={p} />
                   ))}

--- a/src/app/_components/ads.tsx
+++ b/src/app/_components/ads.tsx
@@ -1,12 +1,18 @@
+"use client";
+
+import Link from "next/link";
 import type { common_HeroEntity } from "@/api/proto-http/frontend";
 
 import { calculateAspectRatio } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
 import Image from "@/components/ui/image";
-import ProductsGrid from "@/app/_components/product-grid";
+import { Text } from "@/components/ui/text";
+
+import { ProductItem } from "./product-item";
 
 export function Ads({ entities }: { entities: common_HeroEntity[] }) {
   return (
-    <div>
+    <div className="space-y-20">
       {entities?.map((e, i) => {
         switch (e.type) {
           case "HERO_TYPE_SINGLE":
@@ -27,9 +33,9 @@ export function Ads({ entities }: { entities: common_HeroEntity[] }) {
             return (
               <div
                 key={e.double?.left?.media?.id}
-                className="grid grid-cols-2 gap-3"
+                className="flex h-screen w-full flex-col lg:flex-row"
               >
-                <div className="relative col-span-1 h-[600px]">
+                <div className="relative z-0 h-full w-full">
                   <Image
                     src={e.double?.left?.media?.media?.fullSize?.mediaUrl || ""}
                     alt="ad hero image"
@@ -37,12 +43,27 @@ export function Ads({ entities }: { entities: common_HeroEntity[] }) {
                       e.double?.left?.media?.media?.fullSize?.width,
                       e.double?.left?.media?.media?.fullSize?.height,
                     )}
+                    fit="cover"
                     // blurHash={media.media?.blurhash}
                   />
+                  <div className="absolute inset-0 z-10 flex flex-col items-center justify-center space-y-6">
+                    <Text variant="uppercase" className="text-white">
+                      {e.double?.left?.headline}
+                    </Text>
+                    <Button
+                      variant="underline"
+                      className="uppercase text-white"
+                      asChild
+                    >
+                      <Link href={e.double?.left?.exploreLink || ""}>
+                        {e.double?.left?.exploreText}
+                      </Link>
+                    </Button>
+                  </div>
                 </div>
                 <div
                   key={e.double?.right?.media?.id}
-                  className="relative col-span-1 h-[600px]"
+                  className="relative z-0 h-full w-full"
                 >
                   <Image
                     src={
@@ -53,13 +74,45 @@ export function Ads({ entities }: { entities: common_HeroEntity[] }) {
                       e.double?.right?.media?.media?.fullSize?.width,
                       e.double?.right?.media?.media?.fullSize?.height,
                     )}
+                    fit="cover"
                   />
+                  <div className="absolute inset-0 z-10 flex flex-col items-center justify-center space-y-6">
+                    <Text variant="uppercase" className="text-white">
+                      {e.double?.right?.headline}
+                    </Text>
+                    <Button
+                      variant="underline"
+                      className="uppercase text-white"
+                      asChild
+                    >
+                      <Link href={e.double?.right?.exploreLink || ""}>
+                        {e.double?.right?.exploreText}
+                      </Link>
+                    </Button>
+                  </div>
                 </div>
               </div>
             );
           case "HERO_TYPE_FEATURED_PRODUCTS":
             return (
-              <ProductsGrid key={i} products={e.featuredProducts?.products} />
+              // <ProductsGrid key={i} products={e.featuredProducts?.products} />
+              <div className="space-y-10">
+                <div className="flex flex-col gap-2 md:flex-row">
+                  <Text variant="uppercase">
+                    {e.featuredProducts?.headline}
+                  </Text>
+                  <Button variant="underline" className="uppercase" asChild>
+                    <Link href={e.featuredProducts?.exploreLink || ""}>
+                      {e.featuredProducts?.exploreText}
+                    </Link>
+                  </Button>
+                </div>
+                <div className="flex gap-10 overflow-x-scroll">
+                  {e.featuredProducts?.products?.map((p) => (
+                    <ProductItem className="w-[282px]" key={p.id} product={p} />
+                  ))}
+                </div>
+              </div>
             );
           default:
             return null;

--- a/src/app/_components/main-ads.tsx
+++ b/src/app/_components/main-ads.tsx
@@ -9,7 +9,7 @@ export function MainAds({ main }: { main?: common_HeroMain }) {
   if (!main) return null;
 
   return (
-    <div className="h-screen w-full">
+    <div className="h-[calc(100vh-16px)] w-full lg:h-[calc(100vh-56px)]">
       <div className="absolute inset-0 z-0 h-screen">
         <Image
           src={main.single?.media?.media?.fullSize?.mediaUrl!}
@@ -22,22 +22,15 @@ export function MainAds({ main }: { main?: common_HeroMain }) {
       <div className="absolute inset-0 z-10 flex h-screen items-center">
         <div className="flex flex-col items-start gap-6 p-2 md:flex-row md:justify-between ">
           <Text variant="uppercase" className="text-white">
-            collection
-            {/* now doesn't work*/}
-            {/* {main.tag} */}
+            {main.tag}
           </Text>
           <Text variant="uppercase" className="text-white">
-            Light_leather_organza
-            {/* now doesn't work*/}
-            {/* {main.single?.headline} */}
+            {main.single?.headline}
           </Text>
           <Text variant="uppercase" className="text-white md:w-1/3">
-            Actor Ethan Ruan is featured in the next chapter of Community as a
-            Form of Research wearing
-            {/* now doesn't work*/}
-            {/* {main.description} */}
+            {main.description}
           </Text>
-          <Button asChild variant="underline" className="text-white">
+          <Button variant="underline" className="uppercase text-white" asChild>
             <Link href={main.single?.exploreLink || ""}>
               {main.single?.exploreText}
             </Link>

--- a/src/app/_components/main-ads.tsx
+++ b/src/app/_components/main-ads.tsx
@@ -19,6 +19,7 @@ export function MainAds({ main }: { main?: common_HeroMain }) {
           // blurHash={media.media?.blurhash}
         />
       </div>
+      <div className="absolute inset-0 z-[1] h-screen bg-black opacity-40"></div>
       <div className="absolute inset-0 z-10 flex h-screen items-center">
         <div className="flex flex-col items-start gap-6 p-2 md:flex-row md:justify-between ">
           <Text variant="uppercase" className="text-white">

--- a/src/app/_components/product-item.tsx
+++ b/src/app/_components/product-item.tsx
@@ -28,7 +28,7 @@ export function ProductItem({
     <div className={cn("relative", className)}>
       <Button asChild>
         <Link href={product?.slug || ""}>
-          <div className="relative h-80">
+          <div className={cn("relative h-80", className)}>
             <Image
               src={
                 product.productDisplay?.thumbnail?.media?.thumbnail?.mediaUrl ||


### PR DESCRIPTION
1)изменил стили для родительского контейнера в main-ads, потому что при h-screen у него появляется лишняя высота. хз как по-другому это можно пофиксить
2)добавил скроллер для продуктов => тоже не особо уверен в том, что там все сделано правильно
3)зарефакторил дабл эд
![IMAGE 2024-12-27 20:18:58](https://github.com/user-attachments/assets/a323b4ad-7bb5-4b5a-a9c5-7f922d9fcb87)


- [x] opacity for main ads section added
- [x] opacity for double ads section added
- [x] no-scroll-bar class from global.css added for hero featured products

