### PR TITLE
Fix checkout login form shown after successful sign-in.

### DIFF
--- a/src/app/[locale]/(checkout)/checkout/_components/checkout-form-wrapper.tsx
+++ b/src/app/[locale]/(checkout)/checkout/_components/checkout-form-wrapper.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import type { StorefrontAccount } from "@/api/proto-http/frontend";
 import { LANGUAGE_ID_TO_LOCALE } from "@/constants";
@@ -77,22 +77,29 @@ export function CheckoutFormWrapper({
     isOrderRedirecting,
   ]);
 
+  useLayoutEffect(() => {
+    if (!initialAccount) return;
+
+    setSessionAccount(initialAccount);
+    setSignedIn(true);
+    setAccount(storefrontAccountToProfile(initialAccount));
+    setResolvingSession(false);
+  }, [initialAccount, setAccount, setSignedIn]);
+
   useEffect(() => {
     let active = true;
+    let resolveGeneration = 0;
 
     if (initialAccount) {
-      setSessionAccount(initialAccount);
-      setSignedIn(true);
-      setAccount(storefrontAccountToProfile(initialAccount));
-      setResolvingSession(false);
       return;
     }
 
     setResolvingSession(true);
 
     async function resolveSession() {
+      const generation = ++resolveGeneration;
       const account = await resolveAccountSession();
-      if (!active) return;
+      if (!active || generation !== resolveGeneration) return;
 
       if (account) {
         setSessionAccount(account);

--- a/src/app/[locale]/(checkout)/checkout/_components/new-order-form/index.tsx
+++ b/src/app/[locale]/(checkout)/checkout/_components/new-order-form/index.tsx
@@ -190,7 +190,8 @@ export default function NewOrderForm({
     paymentMethod,
   });
 
-  const showCheckoutFields = isSignedIn || guestCheckout;
+  const showCheckoutFields =
+    isSignedIn || guestCheckout || Boolean(initialAccount);
   const hideOrderSummary = !showCheckoutFields && checkoutLoginStep === "code";
   const showProfilePrompt =
     isSignedIn &&

--- a/src/app/[locale]/account/authorization/api.ts
+++ b/src/app/[locale]/account/authorization/api.ts
@@ -1,8 +1,11 @@
+import type { StorefrontAccount } from "@/api/proto-http/frontend";
+
 import { parseApiError } from "@/app/[locale]/account/utils/api-error";
 
 type ApiResult = {
   ok: boolean;
   error?: string;
+  account?: StorefrontAccount | null;
 };
 
 export async function requestAccountLoginCode(
@@ -43,5 +46,9 @@ export async function verifyAccountLoginCode(
     };
   }
 
-  return { ok: true };
+  const payload = (await response.json()) as {
+    account?: StorefrontAccount | null;
+  };
+
+  return { ok: true, account: payload.account ?? null };
 }

--- a/src/app/[locale]/account/utils/use-account-login.ts
+++ b/src/app/[locale]/account/utils/use-account-login.ts
@@ -7,6 +7,11 @@ import {
   verifyAccountLoginCode,
 } from "../authorization/api";
 import { getErrorMessage } from "@/lib/error-message";
+import {
+  invalidateAccountSessionCache,
+  storefrontAccountToProfile,
+} from "@/lib/storefront-account/client-session";
+import { useAccountOnboardingStore } from "@/lib/stores/account-onboarding/store-provider";
 
 const RESEND_TIMEOUT_SECONDS = 60;
 const LOGIN_ATTEMPT_STORAGE_KEY = "account-login-attempt";
@@ -217,6 +222,8 @@ function getActiveCooldownForEmail(
 export function useAccountLogin() {
   const router = useRouter();
   const t = useTranslations("account");
+  const setSignedIn = useAccountOnboardingStore((s) => s.setSignedIn);
+  const setAccount = useAccountOnboardingStore((s) => s.setAccount);
   const [email, setEmail] = useState("");
   const [code, setCode] = useState("");
   const [step, setStep] = useState<LoginStep>("email");
@@ -375,6 +382,11 @@ export function useAccountLogin() {
         }
         openErrorToast(errorMessage);
         return;
+      }
+      if (result.account) {
+        invalidateAccountSessionCache();
+        setSignedIn(true);
+        setAccount(storefrontAccountToProfile(result.account));
       }
       setCodeVerified(true);
       clearAccountLoginPersistence();

--- a/src/app/[locale]/login/magic-success/magic-login-success-client.tsx
+++ b/src/app/[locale]/login/magic-success/magic-login-success-client.tsx
@@ -5,6 +5,12 @@ import { useRouter } from "next/navigation";
 import { LANGUAGE_ID_TO_LOCALE } from "@/constants";
 import { useTranslations } from "next-intl";
 
+import {
+  invalidateAccountSessionCache,
+  resolveAccountSession,
+  storefrontAccountToProfile,
+} from "@/lib/storefront-account/client-session";
+import { useAccountOnboardingStore } from "@/lib/stores/account-onboarding/store-provider";
 import { CartStoreContext, useCart } from "@/lib/stores/cart/store-provider";
 import { useTranslationsStore } from "@/lib/stores/translations/store-provider";
 import FlexibleLayout from "@/components/flexible-layout";
@@ -19,6 +25,8 @@ export function MagicLoginSuccessClient() {
   const router = useRouter();
   const tAccount = useTranslations("account");
   const tNav = useTranslations("navigation");
+  const setSignedIn = useAccountOnboardingStore((s) => s.setSignedIn);
+  const setAccount = useAccountOnboardingStore((s) => s.setAccount);
   const { currentCountry, languageId } = useTranslationsStore((s) => s);
   const cartStore = useContext(CartStoreContext);
   const [cartHydrated, setCartHydrated] = useState(() =>
@@ -47,7 +55,14 @@ export function MagicLoginSuccessClient() {
 
   useEffect(() => {
     clearAccountLoginPersistence();
-  }, []);
+    invalidateAccountSessionCache();
+    void resolveAccountSession().then((account) => {
+      if (!account) return;
+      setSignedIn(true);
+      setAccount(storefrontAccountToProfile(account));
+    });
+    router.refresh();
+  }, [router, setAccount, setSignedIn]);
 
   useEffect(() => {
     if (!cartHydrated) return;

--- a/src/lib/storefront-account/client-session.ts
+++ b/src/lib/storefront-account/client-session.ts
@@ -3,6 +3,10 @@ import type { AccountProfile } from "@/lib/stores/account-onboarding/store-types
 
 let accountSessionPromise: Promise<StorefrontAccount | null> | null = null;
 
+export function invalidateAccountSessionCache(): void {
+  accountSessionPromise = null;
+}
+
 export function storefrontAccountToProfile(
   account: StorefrontAccount,
 ): AccountProfile {

--- a/src/lib/storefront-account/get-storefront-account.ts
+++ b/src/lib/storefront-account/get-storefront-account.ts
@@ -1,20 +1,11 @@
-import { cookies } from "next/headers";
-
 import type { StorefrontAccount } from "@/api/proto-http/frontend";
 
-import { createAccountServiceClient } from "./authed-client";
-import { ACCESS_COOKIE } from "./session-cookies";
+import { executeWithAccountSession } from "./session-executor";
 
 export async function getStorefrontAccount(): Promise<StorefrontAccount | null> {
-  const store = await cookies();
-  const access = store.get(ACCESS_COOKIE)?.value;
-  if (!access) return null;
-
-  try {
-    const client = createAccountServiceClient(() => access);
-    const result = await client.GetAccount({});
-    return result.account ?? null;
-  } catch {
-    return null;
-  }
+  const result = await executeWithAccountSession((client) =>
+    client.GetAccount({}),
+  );
+  if (!result.ok) return null;
+  return result.data.account ?? null;
 }

--- a/src/lib/stores/account-onboarding/store-provider.tsx
+++ b/src/lib/stores/account-onboarding/store-provider.tsx
@@ -43,18 +43,32 @@ export function AccountOnboardingStoreProvider({
   }
 
   useEffect(() => {
-    storeRef.current?.getState().setSignedIn(initialSignedIn);
-    storeRef.current?.getState().setAccount(initialAccount);
+    const state = storeRef.current?.getState();
+    if (!state) return;
+
+    if (initialSignedIn) {
+      state.setSignedIn(true);
+      if (initialAccount) {
+        state.setAccount(initialAccount);
+      }
+      return;
+    }
+
+    if (!state.isSignedIn) {
+      state.setAccount(initialAccount);
+    }
   }, [initialSignedIn, initialAccount]);
 
   useEffect(() => {
     let active = true;
     let lastCheckedAt = 0;
+    let hydrateGeneration = 0;
 
     async function hydrateSession() {
+      const generation = ++hydrateGeneration;
       lastCheckedAt = Date.now();
       const account = await resolveAccountSession();
-      if (!active) return;
+      if (!active || generation !== hydrateGeneration) return;
 
       const state = storeRef.current?.getState();
       if (!state) return;


### PR DESCRIPTION
Keep client auth state in sync with cookies and SSR by refreshing expired sessions on the server, updating the store immediately after login, and guarding against stale session resolution races.