### PR TITLE
feat: minimal read-only WebMCP catalog tool + api-catalog Link rel

### DIFF
--- a/src/app/template.tsx
+++ b/src/app/template.tsx
@@ -19,6 +19,7 @@ import type { CurrencyRate } from "@/lib/stores/translations/store-types";
 import { DataContextProvider } from "@/components/contexts/DataContext";
 import { ServerActionsContextProvider } from "@/components/contexts/ServerActionsContext";
 import { UrlCountrySync } from "@/components/url-country-sync";
+import { WebMCPTools } from "@/components/webmcp-tools";
 
 export default async function Template({
   children,
@@ -76,6 +77,7 @@ export default async function Template({
                   <UrlCountrySync />
                   <CartCurrencySyncWrapper>
                     <DataContextProvider {...heroData}>
+                      <WebMCPTools />
                       {children}
                     </DataContextProvider>
                   </CartCurrencySyncWrapper>

--- a/src/components/webmcp-tools.tsx
+++ b/src/components/webmcp-tools.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { useEffect } from "react";
+import type { common_Product } from "@/api/proto-http/frontend";
+
+import { useServerActionsContext } from "@/components/contexts/ServerActionsContext";
+
+// Minimal, read-only WebMCP integration: exposes a single catalog-browsing tool
+// to in-browser AI agents via the experimental navigator.modelContext API.
+// Feature-detected and wrapped in try/catch, so it is a no-op everywhere the API
+// is absent (i.e. everywhere except Chrome's WebMCP preview). Intentionally NO
+// mutating actions (cart, checkout, account) — it only reads the public catalog
+// through the existing GetProductsPaged server action.
+
+const SITE = "https://grbpwr.com";
+
+function productPath(slug: string | undefined): string | null {
+  if (!slug) return null;
+  const i = slug.indexOf("/product/");
+  return i === -1 ? null : slug.slice(i);
+}
+
+function toCompactProduct(p: common_Product) {
+  const translations = p.productDisplay?.productBody?.translations;
+  const name = (translations?.[0]?.name || p.sku || "").trim();
+  const media = p.productDisplay?.thumbnail?.media;
+  const image =
+    media?.compressed?.mediaUrl ||
+    media?.fullSize?.mediaUrl ||
+    media?.thumbnail?.mediaUrl;
+  const priceObj = p.prices?.[0];
+  const amount = (priceObj?.price as { value?: string } | undefined)?.value;
+  const path = productPath(p.slug);
+  return {
+    id: p.id,
+    sku: p.sku,
+    name,
+    url: path ? `${SITE}${path}` : undefined,
+    image: image?.trim() || undefined,
+    price: amount ? { amount, currency: priceObj?.currency } : undefined,
+    soldOut: p.soldOut ?? false,
+  };
+}
+
+export function WebMCPTools() {
+  const { GetProductsPaged } = useServerActionsContext();
+
+  useEffect(() => {
+    const mc = (navigator as any)?.modelContext;
+    if (!mc || typeof mc.provideContext !== "function") return;
+
+    async function execute(args: any) {
+      const limit = Math.min(Math.max(Number(args?.limit) || 12, 1), 50);
+      const sort = args?.sort;
+      const sortFactors: any =
+        sort === "price_asc" || sort === "price_desc"
+          ? ["SORT_FACTOR_PRICE"]
+          : ["SORT_FACTOR_CREATED_AT"];
+      const orderFactor: any =
+        sort === "price_asc" ? "ORDER_FACTOR_ASC" : "ORDER_FACTOR_DESC";
+
+      const tag =
+        typeof args?.tag === "string" && args.tag.trim()
+          ? args.tag.trim()
+          : undefined;
+
+      const res = await GetProductsPaged({
+        limit,
+        offset: 0,
+        sortFactors,
+        orderFactor,
+        filterConditions: {
+          from: undefined,
+          to: undefined,
+          currency: undefined,
+          onSale: args?.onSale ? true : undefined,
+          gender: undefined,
+          color: undefined,
+          topCategoryIds: undefined,
+          subCategoryIds: undefined,
+          typeIds: undefined,
+          sizesIds: undefined,
+          preorder: undefined,
+          byTag: tag,
+          collections: undefined,
+          seasons: undefined,
+        },
+      });
+
+      const products = (res.products || []).map(toCompactProduct);
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(
+              { total: res.total ?? products.length, products },
+              null,
+              2,
+            ),
+          },
+        ],
+      };
+    }
+
+    try {
+      mc.provideContext({
+        tools: [
+          {
+            name: "list_products",
+            description:
+              "Browse the grbpwr storefront catalog (read-only). Returns products with name, price, product-page URL and image.",
+            inputSchema: {
+              type: "object",
+              properties: {
+                limit: {
+                  type: "number",
+                  description: "Max products to return (1–50, default 12).",
+                },
+                onSale: {
+                  type: "boolean",
+                  description: "Only return products currently on sale.",
+                },
+                tag: {
+                  type: "string",
+                  description: "Filter by product tag.",
+                },
+                sort: {
+                  type: "string",
+                  enum: ["newest", "price_asc", "price_desc"],
+                  description: "Sort order (default: newest).",
+                },
+              },
+              additionalProperties: false,
+            },
+            execute,
+          },
+        ],
+      });
+    } catch {
+      // Experimental API surface — ignore registration failures.
+    }
+  }, [GetProductsPaged]);
+
+  return null;
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -7,11 +7,11 @@ import { clearSuggestCookies, getLocaleFromCountry, getNormalizedCountry, handle
 
 const intlMiddleware = createMiddleware(routing);
 
-// Agent-discovery Link header (RFC 8288) for the homepage: advertise the
-// markdown alternate (see Markdown-for-Agents above) and the sitemap. Only
-// resources that exist and are locale-agnostic are listed.
+// Agent-discovery Link header (RFC 8288) for the homepage: advertise the API
+// catalog (RFC 9727), the markdown alternate (see Markdown-for-Agents above) and
+// the sitemap. Only resources that exist and are locale-agnostic are listed.
 const HOMEPAGE_LINK_HEADER =
-    '</>; rel="alternate"; type="text/markdown", </sitemap.xml>; rel="sitemap"';
+    '</.well-known/api-catalog>; rel="api-catalog", </>; rel="alternate"; type="text/markdown", </sitemap.xml>; rel="sitemap"';
 
 export default async function middleware(req: NextRequest) {
     const { pathname } = req.nextUrl;


### PR DESCRIPTION
- WebMCPTools: registers a single read-only `list_products` tool via the experimental navigator.modelContext API (feature-detected, try/catch, no-op when absent). Backed by the existing GetProductsPaged server action; returns compact product info (name, price, URL, image). No mutating/cart/checkout actions are exposed.
- Add rel="api-catalog" to the homepage Link header now that the catalog exists (matches RFC 9727 / the discovery example exactly).