### PR TITLE
seo: hreflang sitemap, robots hardening, noindex utility pages

### DIFF
--- a/src/app/[locale]/(content)/layout.tsx
+++ b/src/app/[locale]/(content)/layout.tsx
@@ -1,0 +1,18 @@
+import type { Metadata } from "next";
+
+// Utility / legal content pages (faq, legal-notices, client-services,
+// aftersale-services, return, order-status, unsubscribe) should not surface in
+// search results or Google sitelinks. noindex removes them from the index while
+// follow keeps link equity flowing. These pages are intentionally absent from
+// the sitemap for the same reason.
+export const metadata: Metadata = {
+  robots: { index: false, follow: true },
+};
+
+export default function ContentLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <>{children}</>;
+}

--- a/src/app/robots.txt/route.ts
+++ b/src/app/robots.txt/route.ts
@@ -9,6 +9,12 @@ Content-Signal: search=yes, ai-input=yes, ai-train=yes
 Allow: /
 Disallow: /api/
 Disallow: /admin/
+Disallow: /*/cart
+Disallow: /*/checkout
+Disallow: /*/account
+Disallow: /*/login
+Disallow: /*/order
+Disallow: /*?
 
 Sitemap: https://grbpwr.com/sitemap.xml
 `;

--- a/src/lib/sitemap/build-entries.ts
+++ b/src/lib/sitemap/build-entries.ts
@@ -41,23 +41,48 @@ function pagesPriority(path: string): number {
   return 0.85;
 }
 
+/** Absolute URL for a relative path in a given locale's canonical country. */
+export function localizedSitemapUrl(
+  locale: (typeof routing.locales)[number],
+  relPath: string,
+): string {
+  const country = CANONICAL_COUNTRY_BY_LOCALE[locale];
+  return `${SITEMAP_PUBLIC_BASE_URL}/${country}/${locale}${relPath}`;
+}
+
+/** hreflang alternates for a relative path: every locale + x-default (default locale). */
+export function hreflangAlternates(
+  relPath: string,
+): { hreflang: string; href: string }[] {
+  const alternates: { hreflang: string; href: string }[] = routing.locales.map(
+    (locale) => ({
+      hreflang: locale,
+      href: localizedSitemapUrl(locale, relPath),
+    }),
+  );
+  alternates.push({
+    hreflang: "x-default",
+    href: localizedSitemapUrl(routing.defaultLocale, relPath),
+  });
+  return alternates;
+}
+
 function expandRelPaths(
   relPaths: readonly string[],
   priorityFor: (path: string) => number,
 ): SitemapUrlEntry[] {
   const entries: SitemapUrlEntry[] = [];
-  const now = new Date();
 
-  for (const locale of routing.locales) {
-    const country = CANONICAL_COUNTRY_BY_LOCALE[locale];
-
-    for (const path of relPaths) {
-      const urlPath = `/${country}/${locale}${path}`;
+  for (const path of relPaths) {
+    const alternates = hreflangAlternates(path);
+    for (const locale of routing.locales) {
+      // lastModified is intentionally omitted: these are stable hubs, and a
+      // build-time value would reset every deploy and erode lastmod trust.
       entries.push({
-        url: `${SITEMAP_PUBLIC_BASE_URL}${urlPath}`,
-        lastModified: now,
+        url: localizedSitemapUrl(locale, path),
         changeFrequency: "daily",
         priority: priorityFor(path),
+        alternates,
       });
     }
   }

--- a/src/lib/sitemap/build-product-entries.ts
+++ b/src/lib/sitemap/build-product-entries.ts
@@ -3,7 +3,7 @@ import { LANGUAGE_CODE_TO_ID } from "@/constants";
 import { routing } from "@/i18n/routing";
 import { serviceClient } from "@/lib/api";
 
-import { CANONICAL_COUNTRY_BY_LOCALE, SITEMAP_PUBLIC_BASE_URL } from "./build-entries";
+import { hreflangAlternates, localizedSitemapUrl } from "./build-entries";
 import type { SitemapUrlEntry } from "./serialize-xml";
 
 const SITEMAP_PRODUCT_PAGE_SIZE = 200;
@@ -74,10 +74,9 @@ export async function buildProductSitemapEntries(): Promise<SitemapUrlEntry[]> {
 
       const imageLoc = primaryImageLoc(p);
       const lastMod = p.updatedAt ? new Date(p.updatedAt) : new Date();
+      const alternates = hreflangAlternates(productPath);
 
       for (const locale of routing.locales) {
-        const country = CANONICAL_COUNTRY_BY_LOCALE[locale];
-        const urlPath = `/${country}/${locale}${productPath}`;
         const name = productNameForLocale(p, locale);
         const sku = (p.sku || "").trim();
         const title = sku && name ? `${sku} | ${name}` : name || sku || "product";
@@ -88,11 +87,12 @@ export async function buildProductSitemapEntries(): Promise<SitemapUrlEntry[]> {
             : undefined;
 
         entries.push({
-          url: `${SITEMAP_PUBLIC_BASE_URL}${urlPath}`,
+          url: localizedSitemapUrl(locale, productPath),
           lastModified: lastMod,
           changeFrequency: "daily",
           priority: 0.65,
           images,
+          alternates,
         });
       }
     }

--- a/src/lib/sitemap/serialize-xml.ts
+++ b/src/lib/sitemap/serialize-xml.ts
@@ -8,13 +8,15 @@ function escapeXml(text: string): string {
     .replace(/"/g, "&quot;");
 }
 
-/** One `<url>` row; optional `<image:image>` (Google image extension). */
+/** One `<url>` row; optional `<image:image>` (Google image extension)
+ * and `<xhtml:link>` hreflang alternates (Google international extension). */
 export type SitemapUrlEntry = {
   url: string;
   lastModified?: string | Date;
   changeFrequency?: NonNullable<MetadataRoute.Sitemap[number]>["changeFrequency"];
   priority?: number;
   images?: { loc: string; title?: string; caption?: string }[];
+  alternates?: { hreflang: string; href: string }[];
 };
 
 /** Root `<sitemapindex>` pointing at child sitemaps. */
@@ -36,14 +38,19 @@ export function serializeSitemapIndex(childLocs: string[]): string {
 
 export function serializeUrlset(entries: SitemapUrlEntry[]): string {
   const hasImages = entries.some((e) => e.images && e.images.length > 0);
+  const hasAlternates = entries.some(
+    (e) => e.alternates && e.alternates.length > 0,
+  );
 
   let xml = '<?xml version="1.0" encoding="UTF-8"?>\n';
+  const ns = ['xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"'];
   if (hasImages) {
-    xml +=
-      '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">\n';
-  } else {
-    xml += '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n';
+    ns.push('xmlns:image="http://www.google.com/schemas/sitemap-image/1.1"');
   }
+  if (hasAlternates) {
+    ns.push('xmlns:xhtml="http://www.w3.org/1999/xhtml"');
+  }
+  xml += `<urlset ${ns.join(" ")}>\n`;
 
   for (const item of entries) {
     xml += "<url>\n";
@@ -57,6 +64,11 @@ export function serializeUrlset(entries: SitemapUrlEntry[]): string {
     }
     if (typeof item.priority === "number") {
       xml += `<priority>${item.priority}</priority>\n`;
+    }
+    if (item.alternates?.length) {
+      for (const alt of item.alternates) {
+        xml += `<xhtml:link rel="alternate" hreflang="${escapeXml(alt.hreflang)}" href="${escapeXml(alt.href)}"/>\n`;
+      }
     }
     if (item.images?.length) {
       for (const img of item.images) {


### PR DESCRIPTION
- sitemap: emit xhtml:link hreflang alternates (all 7 locales + x-default) on every page/catalog/product URL — the site had no hreflang anywhere, so locale variants risked being treated as duplicates. Standard per-URL cluster form.
- sitemap: drop build-time lastModified on stable page/catalog hubs (it reset every deploy and eroded lastmod trust); products keep their updatedAt.
- robots.txt: disallow crawling of private/no-SEO routes (cart, checkout, account, login, order) and query-param facet URLs (/*?) to save crawl budget and avoid duplicate faceted pages.
- (content) group: add a layout with robots noindex,follow so utility/legal pages (faq, legal-notices, client/aftersale-services, return, order-status, unsubscribe) stay out of search results and Google sitelinks. They remain intentionally absent from the sitemap.