### PR TITLE
feat: schema.org Product/Offer JSON-LD on product pages

### DIFF
--- a/src/app/[locale]/product/[...productParams]/page.tsx
+++ b/src/app/[locale]/product/[...productParams]/page.tsx
@@ -4,6 +4,7 @@ import { LANGUAGE_CODE_TO_ID } from "@/constants";
 
 import { serviceClient } from "@/lib/api";
 import { generateCommonMetadata } from "@/lib/common-metadata";
+import { productJsonLd } from "@/lib/structured-data";
 
 import { LastViewedProducts } from "./_components/last-viewed-products";
 import { MobileProductInfo } from "./_components/mobile-product-info";
@@ -13,6 +14,7 @@ import { ProductPageLayout } from "./_components/product-page-layout";
 
 interface ProductPageProps {
   params: Promise<{
+    locale: string;
     productParams: string[];
   }>;
 }
@@ -59,7 +61,7 @@ export async function generateMetadata({
 export const dynamic = "force-static";
 
 export default async function ProductPage({ params }: ProductPageProps) {
-  const { productParams } = await params;
+  const { productParams, locale } = await params;
 
   if (productParams.length !== 4) {
     return notFound();
@@ -79,9 +81,16 @@ export default async function ProductPage({ params }: ProductPageProps) {
   }
 
   const productMedia = [...(product?.media || [])];
+  const jsonLd = productJsonLd(product, locale);
 
   return (
     <ProductPageLayout>
+      {jsonLd && (
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        />
+      )}
       <div className="block lg:hidden">
         {product && <MobileProductInfo product={product} />}
       </div>

--- a/src/lib/structured-data.ts
+++ b/src/lib/structured-data.ts
@@ -1,0 +1,82 @@
+import type { common_ProductFull } from "@/api/proto-http/frontend";
+import { LANGUAGE_CODE_TO_ID } from "@/constants";
+
+// schema.org Product/Offer JSON-LD for product pages. Gives search engines (and
+// AI agents) machine-readable price/availability/brand — the "commerce signal"
+// the site was missing. Read-only, derived from the product the page already
+// fetched; no extra requests.
+
+const SITE = "https://grbpwr.com";
+
+const COUNTRY_BY_LOCALE: Record<string, string> = {
+  en: "gb",
+  fr: "fr",
+  de: "de",
+  it: "it",
+  ja: "jp",
+  zh: "cn",
+  ko: "kr",
+};
+
+export function productJsonLd(
+  productFull: common_ProductFull | undefined,
+  locale: string,
+): Record<string, unknown> | null {
+  const p = productFull?.product;
+  if (!p) return null;
+
+  const langId = LANGUAGE_CODE_TO_ID[locale];
+  const translations = p.productDisplay?.productBody?.translations;
+  const t =
+    translations?.find((x) => x.languageId === langId) ?? translations?.[0];
+  const name = (t?.name || p.sku || "").trim();
+  if (!name) return null;
+
+  const country = COUNTRY_BY_LOCALE[locale] ?? "gb";
+  const slug =
+    p.slug && p.slug.includes("/product/")
+      ? p.slug.slice(p.slug.indexOf("/product/"))
+      : null;
+  const url = slug ? `${SITE}/${country}/${locale}${slug}` : undefined;
+
+  const image = (productFull?.media ?? [])
+    .map(
+      (m) =>
+        m?.media?.compressed?.mediaUrl ||
+        m?.media?.fullSize?.mediaUrl ||
+        m?.media?.thumbnail?.mediaUrl,
+    )
+    .map((u) => u?.trim())
+    .filter((u): u is string => Boolean(u))
+    .slice(0, 8);
+
+  const availability = p.soldOut
+    ? "https://schema.org/OutOfStock"
+    : "https://schema.org/InStock";
+
+  const offers = (p.prices ?? [])
+    .filter((pr) => pr?.price?.value && pr.currency)
+    .map((pr) => ({
+      "@type": "Offer",
+      priceCurrency: pr.currency,
+      price: pr.price!.value,
+      availability,
+      ...(url ? { url } : {}),
+    }));
+
+  const description = (t?.description || "").trim();
+  const color = p.productDisplay?.productBody?.productBodyInsert?.color?.trim();
+
+  return {
+    "@context": "https://schema.org",
+    "@type": "Product",
+    name,
+    ...(description ? { description } : {}),
+    ...(image.length ? { image } : {}),
+    ...(p.sku ? { sku: p.sku } : {}),
+    brand: { "@type": "Brand", name: "GRBPWR" },
+    ...(color ? { color } : {}),
+    ...(url ? { url } : {}),
+    ...(offers.length ? { offers } : {}),
+  };
+}


### PR DESCRIPTION
Emit Product structured data (name, image, sku, brand, color, description and per-currency Offer with price + availability + url) as ld+json on each product page. Adds the commerce signal the site was missing → eligible for Google rich results and machine-readable to AI agents. Derived from the product already fetched; no extra requests.