### PR TITLE
Perf/mobile product page

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,10 +73,11 @@
     "typescript": "5.4.3"
   },
   "browserslist": [
-    "chrome >= 64",
-    "edge >= 79",
-    "firefox >= 67",
-    "safari >= 12",
+    "chrome >= 93",
+    "edge >= 93",
+    "firefox >= 92",
+    "safari >= 15.4",
+    "ios_saf >= 15.4",
     "not dead",
     "not op_mini all"
   ],

--- a/src/app/[locale]/_components/footer.tsx
+++ b/src/app/[locale]/_components/footer.tsx
@@ -19,6 +19,7 @@ import { Text } from "@/components/ui/text";
 
 import { FooterNavMobile } from "./footer-nav-mobile";
 import HelpPopover from "./help-popover";
+import { LazyArtIframe } from "./lazy-art-iframe";
 import { MobileCountriesPopupTrigger } from "./mobile-countries-popup";
 import NewslatterForm from "./newsletter-form";
 
@@ -62,16 +63,7 @@ export function Footer({
         <div className="flex justify-center pt-16 lg:py-52">
           <div className="flex w-full flex-col gap-y-16 lg:w-auto lg:flex-row lg:items-start lg:gap-x-20">
             <div className="flex justify-center lg:justify-end">
-              <iframe
-                src={
-                  theme === "dark"
-                    ? "https://art.grbpwr.com/invert"
-                    : "https://art.grbpwr.com"
-                }
-                loading="lazy"
-                className="h-56 w-56 border-0 lg:hidden"
-                title="logo"
-              />
+              <LazyArtIframe theme={theme} />
               {theme === "dark" ? (
                 <Logo className="hidden aspect-square h-full w-40 lg:block" />
               ) : (

--- a/src/app/[locale]/_components/lazy-art-iframe.tsx
+++ b/src/app/[locale]/_components/lazy-art-iframe.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { useInView } from "react-intersection-observer";
+
+// The art.grbpwr.com logo is a footer decoration that pulls ~350 KiB of JS +
+// image from a separate origin. The browser's native iframe lazy-loading still
+// fetches it on short pages, so gate it behind an explicit IntersectionObserver:
+// the iframe only mounts once the footer is ~300px from the viewport, keeping it
+// off the initial LCP critical path. Mobile only (desktop uses a static SVG).
+export function LazyArtIframe({ theme }: { theme?: "light" | "dark" }) {
+  const { ref, inView } = useInView({
+    triggerOnce: true,
+    rootMargin: "300px 0px",
+  });
+
+  const src =
+    theme === "dark" ? "https://art.grbpwr.com/invert" : "https://art.grbpwr.com";
+
+  return (
+    <div ref={ref} className="h-56 w-56 lg:hidden">
+      {inView && (
+        <iframe
+          src={src}
+          loading="lazy"
+          className="h-full w-full border-0"
+          title="logo"
+        />
+      )}
+    </div>
+  );
+}

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -1,5 +1,4 @@
 import { Metadata } from "next";
-import Script from "next/script";
 import { FeatureMono } from "@/fonts";
 import { routing } from "@/i18n/routing";
 import { NextIntlClientProvider } from "next-intl";
@@ -9,9 +8,9 @@ import {
   setRequestLocale,
 } from "next-intl/server";
 
-import { GA4_MEASUREMENT_ID } from "@/lib/analitycs/utils";
 import { generateCommonMetadata } from "@/lib/common-metadata";
 import { AnalyticsInit } from "@/components/analytics-init";
+import { DeferredAnalytics } from "@/components/deferred-analytics";
 import { InternalNavigationTracker } from "@/components/internal-navigation-tracker";
 import { PageTransition } from "@/components/page-transition";
 import { ConsoleArtInit } from "@/components/ui/art/console-art-init";
@@ -88,18 +87,9 @@ export default async function RootLayout({ children, params }: Props) {
         />
       </head>
       <body className={FeatureMono.className}>
-        {/* Analytics deferred to lazyOnload so it doesn't compete with the
-            initial render / hydration on the main thread. */}
-        <Script id="gtm-init" strategy="lazyOnload">
-          {`(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-WFC98J99');`}
-        </Script>
-        <Script
-          src={`https://www.googletagmanager.com/gtag/js?id=${GA4_MEASUREMENT_ID}`}
-          strategy="lazyOnload"
-        />
-        <Script id="gtag-init" strategy="lazyOnload">
-          {`window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','${GA4_MEASUREMENT_ID}',{send_page_view:false});`}
-        </Script>
+        {/* GTM + GA4 load on first interaction (or an idle fallback) to keep
+            third-party JS off the main thread during the initial load. */}
+        <DeferredAnalytics />
         <NextIntlClientProvider locale={locale} messages={messages}>
           <CookieBanner />
           <ToastProvider>

--- a/src/app/[locale]/product/[...productParams]/_components/mobile-image-carousel.tsx
+++ b/src/app/[locale]/product/[...productParams]/_components/mobile-image-carousel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
+import dynamic from "next/dynamic";
 import { common_MediaFull } from "@/api/proto-http/frontend";
 import * as DialogPrimitives from "@radix-ui/react-dialog";
 import useEmblaCarousel from "embla-carousel-react";
@@ -15,7 +16,13 @@ import {
 import { calculateAspectRatio } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import ImageComponent from "@/components/ui/image";
-import { ImageZoom } from "@/components/ui/image-zoom";
+
+// react-zoom-pan-pinch is only needed inside the fullscreen zoom dialog, so load
+// it on demand instead of in the initial product-page bundle.
+const ImageZoom = dynamic(
+  () => import("@/components/ui/image-zoom").then((m) => m.ImageZoom),
+  { ssr: false },
+);
 
 const EMBLA_OPTIONS = {
   loop: true,

--- a/src/app/[locale]/product/[...productParams]/_components/product-images-carousel.tsx
+++ b/src/app/[locale]/product/[...productParams]/_components/product-images-carousel.tsx
@@ -23,6 +23,10 @@ export function ProductImagesCarousel({
   productName,
 }: Props) {
   const oneMedia = productMedia.length === 1;
+  // The carousel initially shows the slides at/after startIndex (not index 0,
+  // which is off-screen). Priority must follow what's actually visible so the
+  // LCP image isn't lazy-loaded.
+  const startIndex = oneMedia ? 0 : 2;
   const prevIndexRef = useRef<number>(-1);
 
   const mediaForCarousel =
@@ -69,13 +73,13 @@ export function ProductImagesCarousel({
       <Carousel
         loop={productMedia.length > 1}
         align={oneMedia ? "start" : "end"}
-        startIndex={oneMedia ? 0 : 2}
+        startIndex={startIndex}
         className="flex h-screen w-full pt-14"
         scrollOnClick={true}
         setSelectedIndex={handleSelectedIndex}
       >
         {mediaForCarousel.map((m, index) => {
-          const isPriority = index < 2;
+          const isPriority = index >= startIndex && index < startIndex + 2;
           return (
             <div
               key={`${m.id}-${index}`}

--- a/src/components/deferred-analytics.tsx
+++ b/src/components/deferred-analytics.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { GA4_MEASUREMENT_ID } from "@/lib/analitycs/utils";
+
+const GTM_ID = "GTM-WFC98J99";
+// Load no later than this even without interaction, so bots/quick-bouncing
+// visitors are still measured.
+const FALLBACK_MS = 6000;
+
+// Loads GTM + gtag only after the first user interaction (or an idle fallback),
+// keeping ~125ms of third-party script work off the main thread during the
+// initial load — the biggest TBT contributor. Tracking behaviour is otherwise
+// identical to the previous inline scripts.
+function injectAnalytics() {
+  // Inject the exact same snippets the layout previously rendered, just later —
+  // using inline <script> text so command processing is byte-identical.
+
+  // Google Tag Manager loader
+  const gtm = document.createElement("script");
+  gtm.text = `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','${GTM_ID}');`;
+  document.head.appendChild(gtm);
+
+  // GA4 library + init (canonical gtag stub)
+  const gtagLib = document.createElement("script");
+  gtagLib.async = true;
+  gtagLib.src = `https://www.googletagmanager.com/gtag/js?id=${GA4_MEASUREMENT_ID}`;
+  document.head.appendChild(gtagLib);
+
+  const gtagInit = document.createElement("script");
+  gtagInit.text = `window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','${GA4_MEASUREMENT_ID}',{send_page_view:false});`;
+  document.head.appendChild(gtagInit);
+}
+
+export function DeferredAnalytics() {
+  useEffect(() => {
+    let loaded = false;
+    const events = ["pointerdown", "keydown", "scroll", "touchstart"] as const;
+
+    const cleanup = () => {
+      events.forEach((e) => window.removeEventListener(e, load));
+      window.clearTimeout(timer);
+    };
+
+    function load() {
+      if (loaded) return;
+      loaded = true;
+      cleanup();
+      injectAnalytics();
+    }
+
+    const timer = window.setTimeout(load, FALLBACK_MS);
+    events.forEach((e) =>
+      window.addEventListener(e, load, { once: true, passive: true }),
+    );
+
+    return cleanup;
+  }, []);
+
+  return null;
+}


### PR DESCRIPTION
Follow-up perf round driven by Lighthouse on the product page (desktop) and the
homepage (mobile).

- **LCP image (product carousel)**: priority/eager now follow the visible slides
  (startIndex), not the off-screen ones — fixes loading=lazy on the LCP image.
- **Legacy JS**: bump browserslist to Chrome 93+/Edge 93+/Firefox 92+/Safari
  15.4+ so SWC stops polyfilling Array.at/Object.hasOwn/etc. (~11.6 KiB).
- **TBT**: GTM + GA4 now load on first interaction (idle fallback) via a
  DeferredAnalytics component — byte-identical snippets, ~125ms off the main
  thread at load. Applies to every route incl. the mobile homepage.
- **Code-split**: ImageZoom (react-zoom-pan-pinch) loaded on demand.
- **Mobile homepage LCP**: the footer art.grbpwr.com iframe (~350 KiB, 3rd
  origin) is gated behind an IntersectionObserver so it no longer loads on the
  initial critical path.

Not in this PR (separate service): art.grbpwr.com asset Cache-Control is
max-age=10 — should be max-age=31536000, immutable (content-hashed assets), best
done via a Cloudflare cache rule.