### PR TITLE
seo: add content freshness signals (dates) across pages

### DIFF
--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -1,8 +1,9 @@
 import { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 
-import { getHero } from "@/lib/api";
+import { getHero, getLatestProductDate } from "@/lib/api";
 import { generateCommonMetadata } from "@/lib/common-metadata";
+import { siteJsonLd } from "@/lib/structured-data";
 import FlexibleLayout from "@/components/flexible-layout";
 import { Disabled } from "@/components/ui/disabled";
 import { EmptyHero } from "@/components/ui/empty-hero";
@@ -32,7 +33,11 @@ export async function generateMetadata({
 }
 
 export default async function Page() {
-  const { hero, dictionary } = await getHero();
+  // Fetch in parallel so the freshness query doesn't add latency to the homepage.
+  const [{ hero, dictionary }, latestProductDate] = await Promise.all([
+    getHero(),
+    getLatestProductDate(),
+  ]);
   const isHero = hero?.entities?.length;
   const isWebsiteEnabled = dictionary?.siteEnabled;
 
@@ -48,8 +53,14 @@ export default async function Page() {
     return <EmptyHero />;
   }
 
+  const jsonLd = siteJsonLd(latestProductDate);
+
   return (
     <FlexibleLayout showAnnounce={true}>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
       {/* <PageBackground imageUrl={heroImageUrl} /> */}
       <MainAds main={hero?.entities?.[0]?.main} />
       <Ads entities={hero?.entities || []} />

--- a/src/app/sitemap_pages.xml/route.ts
+++ b/src/app/sitemap_pages.xml/route.ts
@@ -5,7 +5,7 @@ import { buildPagesSitemapEntries, serializeUrlset } from "@/lib/sitemap";
 export const revalidate = 3600;
 
 export async function GET() {
-  const entries = buildPagesSitemapEntries();
+  const entries = await buildPagesSitemapEntries();
   const xml = serializeUrlset(entries);
   return new NextResponse(xml, {
     headers: {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -82,3 +82,55 @@ export const serviceClient = createFrontendServiceClient(requestHandler);
 // same request. It's a POST, so Next's fetch dedup doesn't cover it — wrap it in
 // React cache() to collapse the two server round-trips into one per request.
 export const getHero = cache(() => serviceClient.GetHero({}));
+
+const EMPTY_FILTERS = {
+  from: undefined,
+  to: undefined,
+  currency: "EUR",
+  onSale: undefined,
+  gender: undefined,
+  color: undefined,
+  topCategoryIds: undefined,
+  subCategoryIds: undefined,
+  typeIds: undefined,
+  sizesIds: undefined,
+  preorder: undefined,
+  byTag: undefined,
+  collections: undefined,
+  seasons: undefined,
+};
+
+// Freshness signals (sitemap lastmod / JSON-LD dateModified) for pages without a
+// single date of their own: derive from the most recently updated content.
+// Cached per request so the homepage and sitemap routes share one round-trip.
+export const getLatestProductDate = cache(
+  async (): Promise<string | undefined> => {
+    try {
+      const { products } = await serviceClient.GetProductsPaged({
+        limit: 1,
+        offset: 0,
+        sortFactors: ["SORT_FACTOR_UPDATED_AT"],
+        orderFactor: "ORDER_FACTOR_DESC",
+        filterConditions: EMPTY_FILTERS,
+      });
+      return products?.[0]?.updatedAt ?? undefined;
+    } catch {
+      return undefined;
+    }
+  },
+);
+
+export const getLatestArchiveDate = cache(
+  async (): Promise<string | undefined> => {
+    try {
+      const { archives } = await serviceClient.GetArchivesPaged({
+        limit: 1,
+        offset: 0,
+        orderFactor: "ORDER_FACTOR_DESC",
+      });
+      return archives?.[0]?.createdAt ?? undefined;
+    } catch {
+      return undefined;
+    }
+  },
+);

--- a/src/lib/sitemap/build-entries.ts
+++ b/src/lib/sitemap/build-entries.ts
@@ -1,5 +1,9 @@
 import { routing } from "@/i18n/routing";
-import { serviceClient } from "@/lib/api";
+import {
+  getLatestArchiveDate,
+  getLatestProductDate,
+  serviceClient,
+} from "@/lib/api";
 
 import {
   CATALOG_SITEMAP_HUB_PATHS,
@@ -70,16 +74,18 @@ export function hreflangAlternates(
 function expandRelPaths(
   relPaths: readonly string[],
   priorityFor: (path: string) => number,
+  // Real content date per path (not build time) — omitted when unavailable.
+  lastModifiedFor?: (path: string) => string | undefined,
 ): SitemapUrlEntry[] {
   const entries: SitemapUrlEntry[] = [];
 
   for (const path of relPaths) {
     const alternates = hreflangAlternates(path);
+    const lastModified = lastModifiedFor?.(path);
     for (const locale of routing.locales) {
-      // lastModified is intentionally omitted: these are stable hubs, and a
-      // build-time value would reset every deploy and erode lastmod trust.
       entries.push({
         url: localizedSitemapUrl(locale, path),
+        ...(lastModified ? { lastModified } : {}),
         changeFrequency: "daily",
         priority: priorityFor(path),
         alternates,
@@ -90,20 +96,31 @@ function expandRelPaths(
   return entries;
 }
 
-export function buildPagesSitemapEntries(): SitemapUrlEntry[] {
-  return expandRelPaths(PAGES_SITEMAP_PATHS, pagesPriority);
+export async function buildPagesSitemapEntries(): Promise<SitemapUrlEntry[]> {
+  // Freshness from real content: homepage tracks the newest product, timeline the
+  // newest archive.
+  const [productDate, archiveDate] = await Promise.all([
+    getLatestProductDate(),
+    getLatestArchiveDate(),
+  ]);
+  return expandRelPaths(PAGES_SITEMAP_PATHS, pagesPriority, (path) =>
+    path === "/timeline" ? archiveDate : productDate,
+  );
 }
 
 export async function buildCatalogSitemapEntries(): Promise<SitemapUrlEntry[]> {
   let relPaths: string[] = [...CATALOG_SITEMAP_HUB_PATHS];
 
-  try {
-    const { dictionary } = await serviceClient.GetHero({});
-    const categories = dictionary?.categories;
-    if (categories?.length) relPaths = collectCatalogSitemapPaths(categories);
-  } catch {
-    // Catalog hubs only if hero/dictionary fails.
-  }
+  const [{ categories } = { categories: undefined }, productDate] =
+    await Promise.all([
+      serviceClient
+        .GetHero({})
+        .then((r) => ({ categories: r.dictionary?.categories }))
+        .catch(() => ({ categories: undefined })),
+      getLatestProductDate(),
+    ]);
 
-  return expandRelPaths(relPaths, catalogPriority);
+  if (categories?.length) relPaths = collectCatalogSitemapPaths(categories);
+
+  return expandRelPaths(relPaths, catalogPriority, () => productDate);
 }

--- a/src/lib/structured-data.ts
+++ b/src/lib/structured-data.ts
@@ -120,6 +120,36 @@ export function productJsonLd(
     brand: { "@type": "Brand", name: "GRBPWR" },
     ...(color ? { color } : {}),
     ...(url ? { url } : {}),
+    ...(p.createdAt ? { datePublished: p.createdAt } : {}),
+    ...(p.updatedAt ? { dateModified: p.updatedAt } : {}),
     ...(offers.length ? { offers } : {}),
+  };
+}
+
+// Organization + WebSite JSON-LD for the homepage. Gives the homepage a content
+// freshness signal (dateModified, derived from the freshest product) and feeds
+// Google's brand knowledge panel / sitelinks search box.
+export function siteJsonLd(dateModified?: string): Record<string, unknown> {
+  return {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "Organization",
+        "@id": `${SITE}/#organization`,
+        name: "GRBPWR",
+        url: SITE,
+        logo: `${SITE}/app-logo.webp`,
+        sameAs: ["https://www.instagram.com/grb.pwr/"],
+      },
+      {
+        "@type": "WebSite",
+        "@id": `${SITE}/#website`,
+        url: SITE,
+        name: "GRBPWR",
+        publisher: { "@id": `${SITE}/#organization` },
+        inLanguage: "en",
+        ...(dateModified ? { dateModified } : {}),
+      },
+    ],
   };
 }


### PR DESCRIPTION
Restore honest, content-derived date signals (no build-time faking) so search engines/agents see the site as fresh:
- Product JSON-LD: datePublished (createdAt) + dateModified (updatedAt).
- Homepage: Organization + WebSite JSON-LD with dateModified from the newest product (also feeds Google's brand panel / sitelinks search box).
- Sitemap lastmod: homepage tracks the newest product, /timeline the newest archive, catalog hubs the newest product. Products already carry updatedAt.

New cached helpers getLatestProductDate / getLatestArchiveDate (one round-trip per request/revalidation, run in parallel with the homepage's hero fetch).