### PR TITLE
ux: blue highlight on mobile catalog card touch

### DIFF
--- a/src/app/[locale]/_components/product-item.tsx
+++ b/src/app/[locale]/_components/product-item.tsx
@@ -105,8 +105,8 @@ export function ProductItem({
             if (!disableAnimations && e.pointerType === "touch")
               setPressed(true);
           }}
-          onPointerUp={onPressEnd}
-          onPointerLeave={onPressEnd}
+          // Keep the highlight on after release (tap navigates → this card
+          // unmounts, clearing it). Only a scroll/drag (pointercancel) clears it.
           onPointerCancel={onPressEnd}
           className={cn("relative", {
             "group-data-[held=true]:animate-threshold-highlight":

--- a/src/app/[locale]/_components/product-item.tsx
+++ b/src/app/[locale]/_components/product-item.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import type { common_Product } from "@/api/proto-http/frontend";
 import {
   currencySymbols,
@@ -41,6 +42,11 @@ export function ProductItem({
   const { currentCountry } = useTranslationsStore((s) => s);
   const { handleSelectItemEvent } = useAnalytics();
   const visited = useVisitedLink(product?.slug);
+
+  // Mobile only: touching a catalog card shows the blue highlight overlay over
+  // the image (like the zoom pulse on the product detail page).
+  const [pressed, setPressed] = useState(false);
+  const onPressEnd = () => setPressed(false);
 
   const currencyKey = currentCountry.currencyKey || "EUR";
   const productBody = product.productDisplay?.productBody?.productBodyInsert;
@@ -95,6 +101,13 @@ export function ProductItem({
         className={cn("group flex h-full w-full flex-col", className)}
       >
         <div
+          onPointerDown={(e) => {
+            if (!disableAnimations && e.pointerType === "touch")
+              setPressed(true);
+          }}
+          onPointerUp={onPressEnd}
+          onPointerLeave={onPressEnd}
+          onPointerCancel={onPressEnd}
           className={cn("relative", {
             "group-data-[held=true]:animate-threshold-highlight":
               !disableAnimations,
@@ -116,7 +129,13 @@ export function ProductItem({
             loading={imagePriority ? "eager" : "lazy"}
           />
           {!disableAnimations && (
-            <Overlay cover="container" color="highlight" trigger="held" />
+            <Overlay
+              cover="container"
+              color="highlight"
+              trigger="active"
+              active={pressed}
+              className="lg:hidden"
+            />
           )}
         </div>
         <div

--- a/src/app/[locale]/account/_components/order-item.tsx
+++ b/src/app/[locale]/account/_components/order-item.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import Link from "next/link";
 import type {
   common_OrderFull,
@@ -13,6 +13,7 @@ import { useTranslationsStore } from "@/lib/stores/translations/store-provider";
 import { useDataContext } from "@/components/contexts/DataContext";
 import { Button } from "@/components/ui/button";
 import Image from "@/components/ui/image";
+import { Overlay } from "@/components/ui/overlay";
 import { Text } from "@/components/ui/text";
 
 import { buildOrderConfirmationUrl } from "../../(checkout)/checkout/_components/new-order-form/utils";
@@ -51,6 +52,10 @@ export function OrderItem({
     );
   }, [dictionary?.shipmentCarriers, order.shipment]);
 
+  // Mobile only: touching the order thumbnails shows the blue highlight, which
+  // stays on until the tap navigates away (this row unmounts). Scroll clears it.
+  const [pressed, setPressed] = useState(false);
+
   return (
     <div className="border-b border-textInactiveColor bg-bgColor py-6 text-textColor first:pt-0">
       <div className="grid grid-cols-2 gap-6 lg:grid-cols-[minmax(0,1fr)_auto]">
@@ -74,14 +79,28 @@ export function OrderItem({
             </Button>
           ) : null}
         </div>
-        <Link href={orderHref} className="flex shrink-0 justify-end gap-2">
+        <Link
+          href={orderHref}
+          className="flex shrink-0 justify-end gap-2"
+          onPointerDown={(e) => {
+            if (e.pointerType === "touch") setPressed(true);
+          }}
+          onPointerCancel={() => setPressed(false)}
+        >
           {order.orderItems?.slice(0, 2).map((i) => (
-            <div key={i.id} className="w-20">
+            <div key={i.id} className="relative w-20">
               <Image
                 src={i.thumbnail ?? ""}
                 fit="contain"
                 aspectRatio="4/5"
                 alt={t("order product thumbnail alt")}
+              />
+              <Overlay
+                cover="container"
+                color="highlight"
+                trigger="active"
+                active={pressed}
+                className="lg:hidden"
               />
             </div>
           ))}


### PR DESCRIPTION
Touching a catalog product card on mobile shows the highlight (blue) overlay over the image while the finger is down — same effect as the product zoom pulse. Touch-only (pointerType check) and lg:hidden, so desktop is unaffected; no scale. Gated behind !disableAnimations (skips recently-viewed/suggest grids).