### PR TITLE
fix: name objects catalog cards from category, not fit

### DIFF
--- a/src/app/[locale]/_components/product-item.tsx
+++ b/src/app/[locale]/_components/product-item.tsx
@@ -66,7 +66,11 @@ export function ProductItem({
   const translatedCategory = singularCategory
     ? t(singularCategory.toLowerCase())
     : "";
-  const name = fit ? `${fit} ${translatedCategory}` : translatedCategory;
+  // Objects use their category/sub-category name as-is (no "fit" prefix that
+  // garments get).
+  const isObjects = topCategory?.toLowerCase() === "objects";
+  const name =
+    fit && !isObjects ? `${fit} ${translatedCategory}` : translatedCategory;
 
   const productPrice =
     product.prices?.find(


### PR DESCRIPTION
Objects products don't have a meaningful "fit", so their catalog card name was rendering as "<fit> <category>" like garments. Use the category/sub-category name as-is for objects (top category === "objects").