### PR TITLE
fix: robust product back navigation (no cycles, never stranded)

### DIFF
--- a/src/app/[locale]/_components/additional-header.tsx
+++ b/src/app/[locale]/_components/additional-header.tsx
@@ -3,6 +3,7 @@
 import { useRouter } from "next/navigation";
 import { LANGUAGE_ID_TO_LOCALE } from "@/constants";
 
+import { canGoBackInApp } from "@/lib/navigation/internal-navigation";
 import { useCart } from "@/lib/stores/cart/store-provider";
 import { useTranslationsStore } from "@/lib/stores/translations/store-provider";
 import { cn } from "@/lib/utils";
@@ -30,7 +31,7 @@ export function AdditionalHeader({
       return;
     }
 
-    if (window.history.length > 1) {
+    if (canGoBackInApp()) {
       router.back();
       return;
     }

--- a/src/app/[locale]/_components/additional-header.tsx
+++ b/src/app/[locale]/_components/additional-header.tsx
@@ -3,7 +3,7 @@
 import { useRouter } from "next/navigation";
 import { LANGUAGE_ID_TO_LOCALE } from "@/constants";
 
-import { canGoBackInApp } from "@/lib/navigation/internal-navigation";
+import { getPreviousPath } from "@/lib/navigation/internal-navigation";
 import { useCart } from "@/lib/stores/cart/store-provider";
 import { useTranslationsStore } from "@/lib/stores/translations/store-provider";
 import { cn } from "@/lib/utils";
@@ -31,8 +31,9 @@ export function AdditionalHeader({
       return;
     }
 
-    if (canGoBackInApp()) {
-      router.back();
+    const prev = getPreviousPath();
+    if (prev) {
+      router.push(prev);
       return;
     }
     try {

--- a/src/app/[locale]/product/[...productParams]/_components/product-page-layout.tsx
+++ b/src/app/[locale]/product/[...productParams]/_components/product-page-layout.tsx
@@ -3,7 +3,7 @@
 import { useRouter } from "next/navigation";
 import { LANGUAGE_ID_TO_LOCALE } from "@/constants";
 
-import { canGoBackInApp } from "@/lib/navigation/internal-navigation";
+import { getPreviousPath } from "@/lib/navigation/internal-navigation";
 import { useTranslationsStore } from "@/lib/stores/translations/store-provider";
 import FlexibleLayout from "@/components/flexible-layout";
 
@@ -25,15 +25,12 @@ export function ProductPageLayout({
   const fallbackPath = gender ? `${homePath}/catalog/${gender}` : homePath;
 
   const handleBack = () => {
-    // Real history pop when we got here in-app — avoids the push(prev) ping-pong
-    // that caused cyclic "back" loops (product↔checkout, product↔recently-viewed).
-    if (typeof window !== "undefined" && canGoBackInApp()) {
-      router.back();
-      return;
-    }
-    // Direct entry / no in-app history: go to the item's gender catalog so the
-    // user is never stranded on the product detail page.
-    router.push(fallbackPath);
+    // Push the specific previous in-app path so the route View Transition plays
+    // (router.back()/popstate doesn't animate). The nav stack makes this safe
+    // from the old ping-pong: at the origin getPreviousPath() is null, so we go
+    // to the item's gender catalog instead of looping — and the user is never
+    // stranded on the product detail page.
+    router.push(getPreviousPath() ?? fallbackPath);
   };
 
   return (

--- a/src/app/[locale]/product/[...productParams]/_components/product-page-layout.tsx
+++ b/src/app/[locale]/product/[...productParams]/_components/product-page-layout.tsx
@@ -3,33 +3,37 @@
 import { useRouter } from "next/navigation";
 import { LANGUAGE_ID_TO_LOCALE } from "@/constants";
 
-import { getPreviousPath } from "@/lib/navigation/internal-navigation";
+import { canGoBackInApp } from "@/lib/navigation/internal-navigation";
 import { useTranslationsStore } from "@/lib/stores/translations/store-provider";
 import FlexibleLayout from "@/components/flexible-layout";
 
-export function ProductPageLayout({ children }: { children: React.ReactNode }) {
+export function ProductPageLayout({
+  children,
+  gender,
+}: {
+  children: React.ReactNode;
+  // Catalog gender of the item (from the URL) — fallback back-target when there
+  // is no in-app history (e.g. arriving via a direct link).
+  gender?: string;
+}) {
   const router = useRouter();
   const { currentCountry, languageId } = useTranslationsStore((s) => s);
 
   const country = currentCountry.countryCode?.toLowerCase() || "gb";
   const locale = LANGUAGE_ID_TO_LOCALE[languageId] || "en";
   const homePath = `/${country}/${locale}`;
+  const fallbackPath = gender ? `${homePath}/catalog/${gender}` : homePath;
 
   const handleBack = () => {
-    if (typeof window === "undefined") {
-      router.push(homePath);
+    // Real history pop when we got here in-app — avoids the push(prev) ping-pong
+    // that caused cyclic "back" loops (product↔checkout, product↔recently-viewed).
+    if (typeof window !== "undefined" && canGoBackInApp()) {
+      router.back();
       return;
     }
-
-    const prevPath = getPreviousPath();
-    const currentPath = `${window.location.pathname}${window.location.search}${window.location.hash}`;
-
-    if (prevPath && prevPath !== currentPath) {
-      router.push(prevPath);
-      return;
-    }
-
-    router.push(homePath);
+    // Direct entry / no in-app history: go to the item's gender catalog so the
+    // user is never stranded on the product detail page.
+    router.push(fallbackPath);
   };
 
   return (

--- a/src/app/[locale]/product/[...productParams]/page.tsx
+++ b/src/app/[locale]/product/[...productParams]/page.tsx
@@ -98,7 +98,7 @@ export default async function ProductPage({ params }: ProductPageProps) {
     "";
 
   return (
-    <ProductPageLayout>
+    <ProductPageLayout gender={gender}>
       {jsonLd && (
         <script
           type="application/ld+json"

--- a/src/components/ui/mobile-nav-cart.tsx
+++ b/src/components/ui/mobile-nav-cart.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect } from "react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import * as DialogPrimitives from "@radix-ui/react-dialog";
 import { useTranslations } from "next-intl";
 
@@ -31,6 +31,13 @@ export function MobileNavCart({
 
   const isMobile = typeof window !== "undefined" && window.innerWidth < 1024;
   const open = isMobile && isOpen;
+  const pathname = usePathname();
+
+  // Never let the cart modal persist across a navigation (avoids it reappearing
+  // when going back from checkout to the product page).
+  useEffect(() => {
+    closeCart();
+  }, [pathname, closeCart]);
 
   useEffect(() => {
     if (open && products.length > 0) {

--- a/src/lib/navigation/internal-navigation.ts
+++ b/src/lib/navigation/internal-navigation.ts
@@ -1,65 +1,67 @@
-const PREV_PATH_KEY = "grbpwr_prev_path";
-const LAST_PATH_KEY = "grbpwr_last_path";
+// Tracks in-app navigation as an explicit stack in sessionStorage so we can tell
+// how deep we are within the app (and what the previous in-app page is) without
+// the prev/last ping-pong the old implementation suffered from. Forward vs back
+// is inferred by comparing the new path with the previous stack entry.
 
-function read(key: string): string | null {
+const STACK_KEY = "grbpwr_nav_stack";
+
+function getStack(): string[] {
   try {
-    return sessionStorage.getItem(key);
+    const raw = sessionStorage.getItem(STACK_KEY);
+    return raw ? (JSON.parse(raw) as string[]) : [];
   } catch {
-    return null;
+    return [];
   }
 }
 
-function write(key: string, value: string): void {
+function setStack(stack: string[]): void {
   try {
-    sessionStorage.setItem(key, value);
-  } catch {
-    /* sessionStorage unavailable */
-  }
-}
-
-function remove(key: string): void {
-  try {
-    sessionStorage.removeItem(key);
+    sessionStorage.setItem(STACK_KEY, JSON.stringify(stack));
   } catch {
     /* sessionStorage unavailable */
   }
 }
 
-export function getPreviousPath(): string | null {
-  return read(PREV_PATH_KEY);
-}
-
+/** Called once when the app first mounts in a tab/session. */
 export function syncNavigationOnEntry(currentPath: string): void {
-  write(LAST_PATH_KEY, currentPath);
-
-  try {
-    const navEntry = performance.getEntriesByType("navigation")[0] as
-      | PerformanceNavigationTiming
-      | undefined;
-
-    if (navEntry?.type !== "navigate") {
-      return;
-    }
-
-    const ref = document.referrer;
-    if (ref && new URL(ref).origin === window.location.origin) {
-      const refPath = `${new URL(ref).pathname}${new URL(ref).search}${new URL(ref).hash}`;
-      write(PREV_PATH_KEY, refPath);
-      return;
-    }
-
-    remove(PREV_PATH_KEY);
-  } catch {
-    remove(PREV_PATH_KEY);
+  const stack = getStack();
+  if (stack.length === 0) {
+    setStack([currentPath]);
+    return;
+  }
+  // Reload of an existing session: keep the stack; only adjust if the top no
+  // longer matches the current path.
+  if (stack[stack.length - 1] !== currentPath) {
+    trackNavigationChange(currentPath);
   }
 }
 
+/** Called on every in-app navigation; maintains the forward/back nav stack. */
 export function trackNavigationChange(currentPath: string): void {
-  const lastPath = read(LAST_PATH_KEY);
-
-  if (lastPath && lastPath !== currentPath) {
-    write(PREV_PATH_KEY, lastPath);
+  const stack = getStack();
+  if (stack.length === 0) {
+    setStack([currentPath]);
+    return;
   }
+  const top = stack[stack.length - 1];
+  if (top === currentPath) return;
 
-  write(LAST_PATH_KEY, currentPath);
+  const prev = stack[stack.length - 2];
+  if (prev === currentPath) {
+    stack.pop(); // back navigation
+  } else {
+    stack.push(currentPath); // forward navigation
+  }
+  setStack(stack);
+}
+
+/** True when there's an in-app page to return to (safe to call router.back()). */
+export function canGoBackInApp(): boolean {
+  return getStack().length > 1;
+}
+
+/** The in-app page we'd return to, or null if we're at the session entry. */
+export function getPreviousPath(): string | null {
+  const stack = getStack();
+  return stack.length > 1 ? stack[stack.length - 2] : null;
 }


### PR DESCRIPTION
Root cause of the cyclic "back" loops (product↔checkout, product↔recently- viewed): the product back button did router.push(prevPath), which grows history and ping-pongs because prevPath was rewritten on every navigation incl. browser back.

- internal-navigation: replace the prev/last keys with an explicit in-app nav stack (forward/back inferred by comparing paths). Adds canGoBackInApp().
- Product back button: router.back() when there's in-app history (a real pop, no ping-pong); otherwise fall back to the item's gender catalog (/catalog/{gender} from the URL) so the user is never stranded on a directly-linked product.
- AdditionalHeader (checkout etc.) back: use canGoBackInApp() instead of the unreliable window.history.length check.
- Mobile cart modal: close on route change so it can't reappear when going back from checkout to the product.

Modal-as-history-entry (browser back closes a modal) is intentionally deferred to a follow-up.