### PR TITLE
fix(mobile): align product header back/cart with main nav position

### DIFF
--- a/src/app/[locale]/_components/mobile-product-info-header.tsx
+++ b/src/app/[locale]/_components/mobile-product-info-header.tsx
@@ -6,11 +6,11 @@ import { MobileNavCart } from "@/components/ui/mobile-nav-cart";
 
 export function MobileProductInfoHeader({ left, link, onClick }: HeaderProps) {
   return (
-    <header className="fixed inset-x-2.5 top-2.5 z-50 flex items-center justify-between">
+    <header className="fixed inset-x-2.5 top-2 z-50 flex h-12 items-center justify-between py-2">
       {onClick ? (
         <AnimatedButton
           onClick={onClick}
-          className="w-1/3 py-2.5 pl-2.5 text-left"
+          className="w-1/3 py-2.5 pl-4 text-left"
           animationArea="text"
           animationDuration={300}
         >
@@ -19,7 +19,7 @@ export function MobileProductInfoHeader({ left, link, onClick }: HeaderProps) {
       ) : (
         <AnimatedButton
           href={link || "/catalog"}
-          className="w-1/3 py-2.5 pl-2.5 text-left"
+          className="w-1/3 py-2.5 pl-4 text-left"
           animationArea="text"
           animationDuration={300}
         >

--- a/src/components/ui/mobile-nav-cart.tsx
+++ b/src/components/ui/mobile-nav-cart.tsx
@@ -49,7 +49,7 @@ export function MobileNavCart({
           className={cn(
             "ml-auto shrink-0 whitespace-nowrap bg-transparent text-right",
             {
-              "w-1/3 py-2.5 pr-2.5": isProductInfo,
+              "w-1/3 py-2.5 pr-4": isProductInfo,
             },
           )}
         >


### PR DESCRIPTION
The product detail mobile header sat at top-2.5 with no fixed height and tighter button padding, so the back/cart buttons jumped vs the main nav (top-2, h-12) when navigating catalog → product.

- Match container geometry: top-2 + h-12 + py-2.
- Back button: pl-2.5 → pl-4 to line up with the menu button's px-4.
- Cart (isProductInfo): pr-2.5 → pr-4 to line up with the main nav cart.