### PR TITLE
i18n(catalog): translate filter "undo" button for all locales

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -141,7 +141,7 @@
     "next": "weiter",
     "empty": "nichts",
     "clear all": "alles löschen",
-    "undo": "undo",
+    "undo": "rückgängig",
     "show": "anzeigen",
     "sort": {
       "latest arrivals": "neueste ankünfte",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -141,7 +141,7 @@
     "next": "suivant",
     "empty": "vide",
     "clear all": "tout effacer",
-    "undo": "undo",
+    "undo": "annuler",
     "show": "afficher",
     "sort": {
       "latest arrivals": "dernières arrivées",

--- a/messages/it.json
+++ b/messages/it.json
@@ -141,7 +141,7 @@
     "next": "avanti",
     "empty": "vuoto",
     "clear all": "tutto rimuovere",
-    "undo": "undo",
+    "undo": "annulla",
     "show": "mostrare",
     "sort": {
       "latest arrivals": "ultimi arrivi",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -141,7 +141,7 @@
     "next": "次へ",
     "empty": "空",
     "clear all": "すべてクリア",
-    "undo": "undo",
+    "undo": "元に戻す",
     "show": "表示",
     "sort": {
       "latest arrivals": "新着アイテム",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -141,7 +141,7 @@
     "next": "다음",
     "empty": "없음",
     "clear all": "모두 지우기",
-    "undo": "undo",
+    "undo": "되돌리기",
     "show": "보기",
     "sort": {
       "latest arrivals": "신상품",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -141,7 +141,7 @@
     "next": "下一个",
     "empty": "空",
     "clear all": "全部清除",
-    "undo": "undo",
+    "undo": "撤销",
     "show": "显示",
     "sort": {
       "latest arrivals": "最新到货",


### PR DESCRIPTION
The catalog category filter undo button (catalog.undo) was the English placeholder "undo" in every non-English locale.

fr annuler · de rückgängig · it annulla · ja 元に戻す · ko 되돌리기 · zh 撤销