### PR TITLE
fix(cookies): raise mobile cookie preferences panel above banner and nav

### DIFF
--- a/src/components/ui/mobile-cookie-modal.tsx
+++ b/src/components/ui/mobile-cookie-modal.tsx
@@ -54,11 +54,11 @@ export function MobileCookieModal({
           </Button>
         </div>
         <DialogPrimitives.Portal>
-          <DialogPrimitives.Overlay className="fixed inset-0 z-10 h-screen bg-overlay" />
+          <DialogPrimitives.Overlay className="fixed inset-0 z-50 h-screen bg-overlay" />
           <ModalTransition
             isOpen={open}
             contentSlideFrom="bottom"
-            contentClassName="fixed inset-x-2 bottom-2 top-2 z-30 flex flex-col gap-4 border border-textInactiveColor bg-bgColor py-4 text-textColor"
+            contentClassName="fixed inset-x-2 bottom-2 top-2 z-[60] flex flex-col gap-4 border border-textInactiveColor bg-bgColor py-4 text-textColor"
             content={
               <DialogPrimitives.Content className="flex h-full flex-col gap-4">
                 <DialogPrimitives.Title className="sr-only">


### PR DESCRIPTION
The mobile preferences modal is portaled out of the cookie banner, but its overlay (z-10) and panel (z-30) sat below the banner (z-40) and the nav (z-30), so the panel rendered underneath them.

- Overlay z-10 → z-50, panel z-30 → z-[60] so it stacks above both.