### PR TITLE
fix(timeline): prevent horizontal scroll from long detail title on mo…

### DIFF
--- a/src/app/[locale]/timeline/[...archiveParams]/_components/page-component.tsx
+++ b/src/app/[locale]/timeline/[...archiveParams]/_components/page-component.tsx
@@ -74,9 +74,12 @@ export default function PageComponent({
   return (
     <div className="w-full space-y-10 text-textColor lg:min-h-screen lg:space-y-14">
       <div className="flex w-full items-center justify-center">
-        <div className="flex w-fit max-w-[640px] flex-col items-start justify-center gap-10">
-          <div className="space-y-4">
-            <Text className="text-textInactiveColor" variant="uppercase">
+        <div className="flex w-full max-w-[640px] flex-col items-start justify-center gap-10">
+          <div className="w-full space-y-4">
+            <Text
+              className="w-full break-words text-textInactiveColor"
+              variant="uppercase"
+            >
               {currentTranslation?.heading || ""}
             </Text>
             <Text variant="uppercase">{`${archive?.archiveList?.tag || ""} / ${currentYear}`}</Text>


### PR DESCRIPTION
…bile

The detail title container used w-fit max-w-[640px], so a long unbroken heading expanded the box up to 640px — wider than a mobile viewport — and the title itself had no word-breaking, causing horizontal page scroll.

- w-fit → w-full so the box never exceeds its (padded) parent.
- Add w-full + break-words to the title so long words wrap.