### PR TITLE
feat(login): allow changing email on the OTP step

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -24,6 +24,7 @@
     "resend code in": "code erneut senden in",
     "or sign in via the link sent to your email": "oder melden sie sich über den link in ihrer e-mail an",
     "or continue using the link sent to your email": "oder fahren sie mit dem link fort, der an ihre e-mail gesendet wurde",
+    "use a different email": "andere e-mail-adresse verwenden",
     "complete your registration": "vervollständigen sie ihre registrierung",
     "country": "land",
     "track order": "bestellung verfolgen",

--- a/messages/en.json
+++ b/messages/en.json
@@ -23,6 +23,7 @@
     "resend code": "resend code",
     "resend code in": "resend code in",
     "or continue using the link sent to your email": "or continue using the link sent to your email",
+    "use a different email": "use a different email",
     "complete your registration": "complete your registration",
     "country": "country",
     "track order": "track order",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -24,6 +24,7 @@
     "resend code in": "renvoyer le code dans",
     "or sign in via the link sent to your email": "ou connectez-vous via le lien envoyé à votre e-mail",
     "or continue using the link sent to your email": "ou continuez avec le lien envoyé à votre e-mail",
+    "use a different email": "utiliser une autre adresse e-mail",
     "complete your registration": "complétez votre inscription",
     "country": "pays",
     "track order": "suivre la commande",

--- a/messages/it.json
+++ b/messages/it.json
@@ -24,6 +24,7 @@
     "resend code in": "invia di nuovo il codice tra",
     "or sign in via the link sent to your email": "oppure accedi tramite il link inviato alla tua email",
     "or continue using the link sent to your email": "oppure continua con il link inviato alla tua email",
+    "use a different email": "usa un'altra email",
     "complete your registration": "completa la tua registrazione",
     "country": "paese",
     "track order": "traccia ordine",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -24,6 +24,7 @@
     "resend code in": "コード再送まで",
     "or sign in via the link sent to your email": "またはメールに送信されたリンクからサインイン",
     "or continue using the link sent to your email": "またはメールに送信されたリンクで続行",
+    "use a different email": "別のメールアドレスを使用",
     "complete your registration": "登録を完了してください",
     "country": "国",
     "track order": "注文を追跡",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -24,6 +24,7 @@
     "resend code in": "코드 재전송까지",
     "or sign in via the link sent to your email": "또는 이메일로 전송된 링크로 로그인하세요",
     "or continue using the link sent to your email": "또는 이메일로 전송된 링크로 계속하세요",
+    "use a different email": "다른 이메일 사용",
     "complete your registration": "회원가입을 완료하세요",
     "country": "국가",
     "track order": "주문 추적",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -24,6 +24,7 @@
     "resend code in": "重新发送倒计时",
     "or sign in via the link sent to your email": "或通过发送到您邮箱的链接登录",
     "or continue using the link sent to your email": "或继续使用发送到您邮箱的链接",
+    "use a different email": "使用其他邮箱",
     "complete your registration": "完成您的注册",
     "country": "国家",
     "track order": "追踪订单",

--- a/src/app/[locale]/account/authorization/account-login-form.tsx
+++ b/src/app/[locale]/account/authorization/account-login-form.tsx
@@ -61,6 +61,7 @@ export function AccountLoginForm({
     sendInitialCode,
     resendCode,
     verifyCode,
+    goToEmailStep,
   } = useAccountLogin();
   const showOrderSummary =
     !isCheckout && step === "email" && products.length > 0;
@@ -132,6 +133,7 @@ export function AccountLoginForm({
                   onCodeChange={setCode}
                   onCodeComplete={verifyCode}
                   onResend={resendCode}
+                  onChangeEmail={goToEmailStep}
                 />
               )}
             </div>
@@ -276,6 +278,7 @@ function CodeStep({
   onCodeChange,
   onCodeComplete,
   onResend,
+  onChangeEmail,
 }: {
   code: string;
   pending: boolean;
@@ -283,6 +286,7 @@ function CodeStep({
   onCodeChange: (value: string) => void;
   onCodeComplete: (code: string) => void;
   onResend: () => void;
+  onChangeEmail: () => void;
 }) {
   const t = useTranslations("account");
 
@@ -327,6 +331,15 @@ function CodeStep({
             <Text variant="uppercase" className="text-textInactiveColor">
               {t("or continue using the link sent to your email")}
             </Text>
+            <Button
+              type="button"
+              variant="underline"
+              className="uppercase"
+              disabled={pending}
+              onClick={onChangeEmail}
+            >
+              {t("use a different email")}
+            </Button>
           </div>
         </div>
       </div>

--- a/src/app/[locale]/account/authorization/account-login-form.tsx
+++ b/src/app/[locale]/account/authorization/account-login-form.tsx
@@ -334,7 +334,7 @@ function CodeStep({
             <Button
               type="button"
               variant="underline"
-              className="uppercase"
+              className="mx-auto w-fit text-center uppercase"
               disabled={pending}
               onClick={onChangeEmail}
             >

--- a/src/app/[locale]/account/utils/use-account-login.ts
+++ b/src/app/[locale]/account/utils/use-account-login.ts
@@ -349,6 +349,18 @@ export function useAccountLogin() {
     await sendLoginCode(true);
   }
 
+  // Go back to the email step from the code step so the user can enter a
+  // different email. The per-email cooldown is intentionally left intact: if
+  // they re-enter the same address, sendLoginCode reuses the existing timer
+  // instead of sending another email.
+  function goToEmailStep() {
+    if (pending) return;
+    setCode("");
+    setCodeVerified(false);
+    setStep("email");
+    clearStoredLoginAttempt();
+  }
+
   async function resendCode() {
     await sendLoginCode(false);
   }
@@ -422,5 +434,6 @@ export function useAccountLogin() {
     sendInitialCode,
     resendCode,
     verifyCode,
+    goToEmailStep,
   };
 }


### PR DESCRIPTION
On the OTP/code step the email was fixed. Add a "use a different email" button under the "or continue using the link sent to your email" text that returns to the email step.

- goToEmailStep() leaves the per-email cooldown intact, so re-entering the same address reuses the existing timer (sendLoginCode reuses the active cooldown) instead of sending another email.
- Add the "use a different email" translation for all 7 locales.