### PR TITLE
fix(checkout): restore Apple Pay / Google Pay in the Payment Element

### DIFF
--- a/src/app/[locale]/(checkout)/checkout/_components/new-order-form/payment-fields-group.tsx
+++ b/src/app/[locale]/(checkout)/checkout/_components/new-order-form/payment-fields-group.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 import { ValidateOrderItemsInsertResponse } from "@/api/proto-http/frontend";
 import { PaymentElement } from "@stripe/react-stripe-js";
+import type { StripePaymentElementOptions } from "@stripe/stripe-js";
 import { useTranslations } from "next-intl";
 import { useFormContext, UseFormReturn } from "react-hook-form";
 
@@ -124,14 +125,16 @@ export default function PaymentFieldsGroup({
                 onChange={handlePaymentElementChange}
                 options={{
                   layout: "tabs",
-                  // Explicitly opt the wallets in. A previous config passed an
-                  // invalid `{ link: "never" }` here (cast to silence the type
-                  // error) — `link` is not a member of PaymentWalletsOption, so
-                  // the malformed object disabled the Apple Pay / Google Pay
-                  // button. Only applePay/googlePay are valid keys.
+                  // Show Apple Pay / Google Pay, hide Stripe Link (we don't want
+                  // its inline email/save form). `link` is honored by stripe.js
+                  // at runtime but was dropped from PaymentWalletsOption in the
+                  // installed types, so the wallets object is widened locally.
                   wallets: {
                     applePay: "auto",
                     googlePay: "auto",
+                    link: "never",
+                  } as StripePaymentElementOptions["wallets"] & {
+                    link: "never";
                   },
                   fields: {
                     billingDetails: {

--- a/src/app/[locale]/(checkout)/checkout/_components/new-order-form/payment-fields-group.tsx
+++ b/src/app/[locale]/(checkout)/checkout/_components/new-order-form/payment-fields-group.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useRef, useState } from "react";
 import { ValidateOrderItemsInsertResponse } from "@/api/proto-http/frontend";
 import { PaymentElement } from "@stripe/react-stripe-js";
-import type { PaymentWalletsOption } from "@stripe/stripe-js";
 import { useTranslations } from "next-intl";
 import { useFormContext, UseFormReturn } from "react-hook-form";
 
@@ -125,9 +124,15 @@ export default function PaymentFieldsGroup({
                 onChange={handlePaymentElementChange}
                 options={{
                   layout: "tabs",
+                  // Explicitly opt the wallets in. A previous config passed an
+                  // invalid `{ link: "never" }` here (cast to silence the type
+                  // error) — `link` is not a member of PaymentWalletsOption, so
+                  // the malformed object disabled the Apple Pay / Google Pay
+                  // button. Only applePay/googlePay are valid keys.
                   wallets: {
-                    link: "never",
-                  } as PaymentWalletsOption,
+                    applePay: "auto",
+                    googlePay: "auto",
+                  },
                   fields: {
                     billingDetails: {
                       address: {


### PR DESCRIPTION
PR #557 added `wallets: { link: "never" } as PaymentWalletsOption` to the Stripe PaymentElement options. `link` is not a member of PaymentWalletsOption (only applePay/googlePay are) — the `as` cast was needed solely to silence that type error. The malformed wallets object made Stripe stop rendering the Apple Pay / Google Pay button.

Replace it with a valid config that explicitly opts the wallets in: wallets: { applePay: "auto", googlePay: "auto" }. Drop the now-unused PaymentWalletsOption import.