### PR TITLE
fix(seo): emit product og:type=product as <meta property> (#7 follow-up)

### DIFF
--- a/src/app/[locale]/product/[...productParams]/page.tsx
+++ b/src/app/[locale]/product/[...productParams]/page.tsx
@@ -47,16 +47,15 @@ export async function generateMetadata({
 
   const color = productBody?.productBodyInsert?.color;
   const productImageUrl = productMedia[0]?.media?.compressed?.mediaUrl;
-  const offer = productOfferForLocale(product, locale);
 
+  // type:"product" suppresses the default og:type=website; og:type=product and
+  // product:price:* are rendered as <meta property> JSX in the component below,
+  // since Next's metadata API can't emit og:type=product.
   return generateCommonMetadata({
     title: title?.toUpperCase(),
     description: `${description}'\n'${color}`,
     locale,
     path: `/product/${gender}/${brand}/${name}/${id}`,
-    ...(offer
-      ? { productPrice: { amount: offer.price, currency: offer.currency } }
-      : {}),
     ogParams: {
       type: "product",
       imageUrl: productImageUrl,
@@ -89,6 +88,10 @@ export default async function ProductPage({ params }: ProductPageProps) {
 
   const productMedia = [...(product?.media || [])];
   const jsonLd = productJsonLd(product, locale);
+  // Open Graph product tags. Rendered here (not via the metadata API, which
+  // throws on og:type values outside its fixed union) as <meta property> JSX —
+  // React hoists them into <head>.
+  const offer = productOfferForLocale(product, locale);
 
   // Single descriptive H1 (the product name) rendered once at page level — both
   // the desktop and mobile info blocks are in the DOM (CSS-toggled), so putting
@@ -109,6 +112,13 @@ export default async function ProductPage({ params }: ProductPageProps) {
           type="application/ld+json"
           dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
         />
+      )}
+      <meta property="og:type" content="product" />
+      {offer && (
+        <>
+          <meta property="product:price:amount" content={offer.price} />
+          <meta property="product:price:currency" content={offer.currency} />
+        </>
       )}
       {productName && <h1 className="sr-only">{productName}</h1>}
       <div className="block lg:hidden">

--- a/src/lib/common-metadata.tsx
+++ b/src/lib/common-metadata.tsx
@@ -67,8 +67,10 @@ type GenerateOgParams = {
   imageWidth?: number;
   imageHeight?: number;
   imageAlt?: string;
-  // "product" pages emit og:type=product (+ product:price:*) via `other` since
-  // Next's typed openGraph union has no "product" variant.
+  // "product" suppresses the default og:type=website here: Next's metadata API
+  // can't emit og:type=product (it throws on types outside its fixed union), so
+  // product pages render og:type=product + product:price:* as <meta property>
+  // JSX themselves. Setting this avoids a duplicate/conflicting og:type tag.
   type?: "website" | "product";
 };
 
@@ -84,8 +86,9 @@ export function generateOpenGraph({
   return {
     title,
     description,
-    // og:type=product is set via `other` (see generateCommonMetadata) to avoid a
-    // duplicate tag; only emit the typed "website" here.
+    // Only emit the typed "website" og:type here. Product pages pass
+    // type:"product" to suppress it and render og:type=product themselves (see
+    // the `type` note above).
     ...(type === "website" ? { type } : {}),
     siteName: "grbpwr.com",
     images: [
@@ -103,7 +106,6 @@ export function generateCommonMetadata({
   title = "grbpwr.com",
   description = "GRBPWR discusses difficult topics by imperfect language and master it. Shop latest ready-to-wear.",
   ogParams = {},
-  productPrice,
   locale,
   path,
 }: {
@@ -111,8 +113,6 @@ export function generateCommonMetadata({
   templateTitle?: string;
   description?: string;
   ogParams?: GenerateOgParams;
-  // Pass for product pages to emit og:type=product + product:price:* tags.
-  productPrice?: { amount: string; currency: string };
   // Pass locale + locale-relative path (e.g. "" or "/product/...") to emit a
   // canonical <link> and hreflang alternates. Omit on layout-level metadata so
   // leaf pages own them.
@@ -121,14 +121,6 @@ export function generateCommonMetadata({
 } = {}): Metadata {
   const canonical = canonicalUrl(locale, path);
   const languages = locale ? languageAlternates(path) : undefined;
-
-  const isProduct = ogParams.type === "product";
-  const other: Record<string, string> = {};
-  if (isProduct) other["og:type"] = "product";
-  if (productPrice) {
-    other["product:price:amount"] = productPrice.amount;
-    other["product:price:currency"] = productPrice.currency;
-  }
 
   return {
     title: {
@@ -161,6 +153,5 @@ export function generateCommonMetadata({
       description: description,
       images: [ogParams.imageUrl || logo.src],
     },
-    ...(Object.keys(other).length ? { other } : {}),
   };
 }


### PR DESCRIPTION
Follow-up to #613. That PR was merged at a state where the product Open Graph tags were set via Next's `other` metadata field — which renders `<meta name=...>`. Open Graph requires `property=`, so scrapers saw **no `og:type`** on product pages (silently defaulting to `website`). This restores the correct, verified fix.

## Why the metadata API can't do it
- Next's `other` field renders `<meta name="…">`, not `<meta property="…">` (invalid for OG).
- Next's OG renderer **throws** (`Invalid OpenGraph type`) on any `og:type` outside its fixed union, so `og:type=product` can't go through `openGraph.type` either (`node_modules/next/dist/lib/metadata/generate/opengraph.js`).

## Fix
- Render `og:type=product` + `product:price:amount`/`currency` as real `<meta property>` JSX in the product server component — React 19 hoists them into `<head>`.
- Pass `ogParams.type:"product"` only to **suppress** the default `og:type=website`, so there's no duplicate/conflicting tag.
- Drop the broken `other`/`productPrice` plumbing from `generateCommonMetadata`.

## Verification (`next build` + `next start` + curl)
- `tsc --noEmit`: clean (non-test files).
- `next build`: 141/141, no "Invalid OpenGraph type" error.
- Product page (`/gb/en/product/...`) emits exactly **one** `<meta property="og:type" content="product">` plus `product:price:amount=150` / `product:price:currency=GBP`.
- Homepage still emits `<meta property="og:type" content="website">`.

Note: the homepage `Cache-Control` vs prerender alignment remains a separate deferred follow-up (not in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)