### PR TITLE
fix(seo): homepage Cache-Control private instead of misleading no-store

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -155,6 +155,14 @@ export default async function middleware(req: NextRequest) {
         if (!rest?.trim()) {
             res.headers.append("Link", HOMEPAGE_LINK_HEADER);
             res.headers.set("Vary", "Accept");
+            // The homepage is prerendered (force-static) and personalised only via
+            // the cookies set below (read client-side), so `private` is the honest
+            // signal vs `no-store`: the browser may reuse it (revalidating first),
+            // shared caches/proxies must not. It still isn't CDN-cached — the
+            // Set-Cookie precludes that — but the header no longer misrepresents a
+            // prerendered page as non-storable, which was confusing diagnostics and
+            // third-party caches/proxies.
+            res.headers.set("Cache-Control", "private, no-cache, must-revalidate");
         }
         setMainCookies(res, country!, locale!);
         const suggestCountryCookie = req.cookies.get("NEXT_SUGGEST_COUNTRY")?.value;


### PR DESCRIPTION
Cosmetic/honesty follow-up. The homepage is prerendered (`force-static`) but middleware still sent `Cache-Control: no-store`, which misrepresents a prerendered page as non-storable and was confusing diagnostics and third-party caches/proxies.

## Change
Homepage now sends `Cache-Control: private, no-cache, must-revalidate` instead of `no-store`:
- The page's HTML is static; personalisation is purely client-side via the `NEXT_COUNTRY`/`NEXT_LOCALE` cookies.
- `private` = the browser may store it (revalidating first), shared caches/proxies must not.

## What is intentionally NOT changed
- This does **not** enable CDN edge caching — the per-request `Set-Cookie` already precludes shared caching, and the cookie-sync logic is left untouched (verified `Set-Cookie` still present).
- Non-home paths keep `no-store`.

## Verification (`next start` + curl)
- `GET /gb/en` → `cache-control: private, no-cache, must-revalidate`, `Set-Cookie: NEXT_COUNTRY/NEXT_LOCALE` still present.
- `GET /gb/en/catalog` → `cache-control: no-store` (unchanged).
- `tsc --noEmit` clean; `next build` 141/141.

🤖 Generated with [Claude Code](https://claude.com/claude-code)