### PR TITLE
fix(routing): bare /{country} resolves to that country (not a mistaken locale)

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -188,6 +188,22 @@ export default async function middleware(req: NextRequest) {
         return res;
     }
 
+    // A bare /{country} (e.g. /gb, /us) must resolve to that country, not be
+    // mistaken for a locale by the locale-only handling below (which treats any
+    // two letters as a language). Redirect to the country's default language so
+    // /gb -> /gb/en instead of /{geoCountry}/{geoLocale}.
+    const bareCountry = pathname.match(/^\/([A-Za-z]{2})\/?$/);
+    if (bareCountry && supportedCountries.includes(bareCountry[1].toLowerCase())) {
+        const country = bareCountry[1].toLowerCase();
+        const locale = getLocaleFromCountry(country);
+        const url = req.nextUrl.clone();
+        url.pathname = `/${country}/${locale}`;
+        const res = NextResponse.redirect(url, { status: 307 });
+        res.headers.set("Cache-Control", "no-store");
+        setMainCookies(res, country, locale);
+        return res;
+    }
+
     //handle paths without country/locale (e.g. /, /en, /en/products)
     if (!/^\/[A-Za-z]{2}\/[a-z]{2}(?=\/|$)/.test(pathname)) {
         const targetCountry = (countryCookie && supportedCountries.includes(countryCookie))


### PR DESCRIPTION
## Bug (🔴 audit A)
A bare single-segment URL like `/gb` ignored the country and forced the geo/cookie default:

```
/gb → /de/de   (expected /gb/en)
/fr → /de/fr
/us → /de/de
/jp → /de/de
```

A Brit opening `/gb` landed on the German site. (307, so not indexed, but broken routing + bad UX for direct/shared links.)

## Root cause
`/gb` has no second segment, so it skips the `/{country}/{locale}` branch and falls into the locale-only handler (`middleware.ts`), whose regex treats any two letters as a language. `gb` isn't in `routing.locales`, so the language collapsed to the geo/cookie default and the country came from geo too.

## Fix
Before the locale-only handling, if a bare `/{country}` segment is a supported country, redirect (307) to `/{country}/{getLocaleFromCountry(country)}` and set cookies.

## Verification (`next start` + curl)
```
/gb → /gb/en    /fr → /fr/fr    /us → /us/en    /it → /it/it    /jp → /jp/ja    /de → /de/de
/en → /gb/en   (en is a locale, not a country → locale-only, geo default)
/ko → /gb/ko   (ko is a locale; Korea's country code is kr → locale-only)
/   → /gb/en   (root still geolocates)
```
`tsc` clean; `next build` 141/141.

🤖 Generated with [Claude Code](https://claude.com/claude-code)