### PR TITLE
fix(security): baseline security headers (no CSP)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -33,7 +33,23 @@ const nextConfig: NextConfig = {
   },
   pageExtensions: ["mdx", "ts", "tsx"],
   async headers() {
+    // Baseline security headers (no CSP — added separately once Stripe/Maps/
+    // analytics origins are enumerated). Applied to every response.
+    const securityHeaders = [
+      { key: 'X-Content-Type-Options', value: 'nosniff' },
+      { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+      { key: 'X-Frame-Options', value: 'SAMEORIGIN' },
+      // Lock down powerful features the storefront doesn't use. Unlisted
+      // features (e.g. payment for Stripe) keep their default allowlist.
+      { key: 'Permissions-Policy', value: 'camera=(), microphone=(), browsing-topics=()' },
+      // HSTS incl. subdomains (files/art.grbpwr.com are HTTPS); no `preload`.
+      { key: 'Strict-Transport-Security', value: 'max-age=63072000; includeSubDomains' },
+    ];
     const headers: { source: string; headers: { key: string; value: string }[] }[] = [
+      {
+        source: '/:path*',
+        headers: securityHeaders,
+      },
       {
         source: '/:all*(svg|jpg|jpeg|png|webp|avif|gif|ico)',
         headers: [


### PR DESCRIPTION
Audit item C. Adds baseline security headers in `next.config.ts` `headers()` for all responses:

| Header | Value |
|---|---|
| `X-Content-Type-Options` | `nosniff` |
| `Referrer-Policy` | `strict-origin-when-cross-origin` |
| `X-Frame-Options` | `SAMEORIGIN` |
| `Permissions-Policy` | `camera=(), microphone=(), browsing-topics=()` |
| `Strict-Transport-Security` | `max-age=63072000; includeSubDomains` |

## Deliberately out of scope
- **CSP / `frame-ancestors`** — needs Stripe, Google Maps, GTM/GA4/Meta origins enumerated and checkout/map testing first; risky to add blind.
- **HSTS `preload`** — not set (irreversible-ish; requires all subdomains HTTPS-ready).
- `Permissions-Policy` only restricts features the storefront doesn't use; unlisted features (e.g. `payment` for Stripe) keep their default allowlist, so checkout is unaffected.

## Verification
`next start` + curl on `/gb/en`: all five headers present. `tsc` clean; `next build` 141/141.

🤖 Generated with [Claude Code](https://claude.com/claude-code)