### PR TITLE
fix(seo): BreadcrumbList + CollectionPage structured data

### DIFF
--- a/src/app/[locale]/catalog/[[...params]]/page.tsx
+++ b/src/app/[locale]/catalog/[[...params]]/page.tsx
@@ -3,9 +3,26 @@ import { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 
 import { generateCommonMetadata } from "@/lib/common-metadata";
+import { catalogJsonLd } from "@/lib/structured-data";
 
 import { CatalogContent } from "../_components/catalog-content";
 import { CatalogSkeleton } from "../_components/catalog-skeleton";
+
+/** Shared resolution of the listing's display title + description key. */
+function resolveCatalogCopy(firstParam?: string) {
+  const p = firstParam?.toLowerCase();
+  const title =
+    p === "men" ? "men" : p === "women" ? "women" : p === "objects" ? "objects" : "catalog";
+  const descriptionKey =
+    p === "men"
+      ? "men description"
+      : p === "women"
+        ? "women description"
+        : p === "objects"
+          ? "objects description"
+          : "catalog description";
+  return { title, descriptionKey };
+}
 
 interface CatalogPageProps {
   params: Promise<{
@@ -43,27 +60,11 @@ export async function generateMetadata({
   const { locale, params: routeParams } = await params;
   const t = await getTranslations({ locale, namespace: "meta" });
 
-  const firstParam = routeParams?.[0]?.toLowerCase();
-  const descriptionKey =
-    firstParam === "men"
-      ? "men description"
-      : firstParam === "women"
-        ? "women description"
-        : firstParam === "objects"
-          ? "objects description"
-          : "catalog description";
-
-  const title =
-    firstParam === "men"
-      ? "men"
-      : firstParam === "women"
-        ? "women"
-        : firstParam === "objects"
-          ? "objects"
-          : t("catalog");
+  const { title, descriptionKey } = resolveCatalogCopy(routeParams?.[0]);
+  const displayTitle = title === "catalog" ? t("catalog") : title;
 
   return generateCommonMetadata({
-    title: title.toUpperCase(),
+    title: displayTitle.toUpperCase(),
     description: t(descriptionKey),
     locale,
     path: routeParams?.length
@@ -72,10 +73,28 @@ export async function generateMetadata({
   });
 }
 
-export default function CatalogPage(props: CatalogPageProps) {
+export default async function CatalogPage(props: CatalogPageProps) {
+  const { locale, params: routeParams } = await props.params;
+  const t = await getTranslations({ locale, namespace: "meta" });
+  const { title, descriptionKey } = resolveCatalogCopy(routeParams?.[0]);
+  const displayTitle = title === "catalog" ? t("catalog") : title;
+
+  const jsonLd = catalogJsonLd({
+    locale,
+    routeParams,
+    name: displayTitle.toUpperCase(),
+    description: t(descriptionKey),
+  });
+
   return (
-    <Suspense fallback={<CatalogSkeleton />}>
-      <CatalogContent {...props} />
-    </Suspense>
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      <Suspense fallback={<CatalogSkeleton />}>
+        <CatalogContent {...props} />
+      </Suspense>
+    </>
   );
 }

--- a/src/lib/structured-data.ts
+++ b/src/lib/structured-data.ts
@@ -153,8 +153,7 @@ export function productJsonLd(
   const description = (t?.description || "").trim();
   const color = p.productDisplay?.productBody?.productBodyInsert?.color?.trim();
 
-  return {
-    "@context": "https://schema.org",
+  const productNode = {
     "@type": "Product",
     name,
     ...(description ? { description } : {}),
@@ -166,6 +165,72 @@ export function productJsonLd(
     ...(p.createdAt ? { datePublished: p.createdAt } : {}),
     ...(p.updatedAt ? { dateModified: p.updatedAt } : {}),
     ...(offers.length ? { offers } : {}),
+  };
+
+  // Breadcrumb: GRBPWR > Catalog > {product}. Helps Google render a breadcrumb
+  // trail in product snippets instead of the bare URL.
+  const homeUrl = `${SITE}/${country}/${locale}`;
+  const breadcrumbNode = {
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      { "@type": "ListItem", position: 1, name: "GRBPWR", item: homeUrl },
+      { "@type": "ListItem", position: 2, name: "Catalog", item: `${homeUrl}/catalog` },
+      { "@type": "ListItem", position: 3, name, ...(url ? { item: url } : {}) },
+    ],
+  };
+
+  return {
+    "@context": "https://schema.org",
+    "@graph": [productNode, breadcrumbNode],
+  };
+}
+
+// CollectionPage + BreadcrumbList for catalog listings (/catalog and category
+// listings). ItemList is intentionally omitted — the catalog loads products
+// client-side (infinite scroll), so there's no server-rendered product list to
+// enumerate; adding it would require a dedicated server fetch.
+export function catalogJsonLd({
+  locale,
+  routeParams,
+  name,
+  description,
+}: {
+  locale: string;
+  routeParams?: string[];
+  name: string;
+  description?: string;
+}): Record<string, unknown> {
+  const country = COUNTRY_BY_LOCALE[locale] ?? "gb";
+  const homeUrl = `${SITE}/${country}/${locale}`;
+  const catalogUrl = `${homeUrl}/catalog`;
+  const url = routeParams?.length
+    ? `${catalogUrl}/${routeParams.join("/")}`
+    : catalogUrl;
+  const category = routeParams?.[0];
+
+  const itemListElement = [
+    { "@type": "ListItem", position: 1, name: "GRBPWR", item: homeUrl },
+    { "@type": "ListItem", position: 2, name: "Catalog", item: catalogUrl },
+    ...(category
+      ? [{ "@type": "ListItem", position: 3, name: category, item: url }]
+      : []),
+  ];
+
+  return {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "CollectionPage",
+        name,
+        url,
+        ...(description ? { description } : {}),
+        isPartOf: { "@type": "WebSite", "@id": `${SITE}/#website` },
+      },
+      {
+        "@type": "BreadcrumbList",
+        itemListElement,
+      },
+    ],
   };
 }
 


### PR DESCRIPTION
Audit item E. Adds structured data to product and catalog listings.

## Changes
- **Product**: `productJsonLd` now returns an `@graph` of `Product` + `BreadcrumbList` (`GRBPWR › Catalog › {product}`). Implemented entirely in `structured-data.ts`, so the product page's existing single JSON-LD `<script>` is unchanged (also avoids touching `product/page.tsx`, which #614 edits).
- **Catalog**: new `catalogJsonLd` emits `CollectionPage` + `BreadcrumbList` (`GRBPWR › Catalog › {category}`), rendered from the catalog page (component made async).

## Deferred
- **`ItemList`** — the catalog loads products client-side (infinite scroll); there's no server-rendered product list to enumerate without a dedicated fetch. Noted in code.

## Verification (`next start` + curl)
- `/gb/en/product/...` → `@graph`: 1 `Product`, 1 `BreadcrumbList` (3 `ListItem`).
- `/gb/en/catalog` → `CollectionPage` + `BreadcrumbList` (2 items).
- `/gb/en/catalog/men` → breadcrumb `GRBPWR › Catalog › men`.
- `tsc` clean; `next build` 141/141.

🤖 Generated with [Claude Code](https://claude.com/claude-code)