### PR TITLE
fix(routing): keep chosen language — relative hero/ad links + bare /{country}

### DIFF
--- a/src/app/[locale]/_components/ads.tsx
+++ b/src/app/[locale]/_components/ads.tsx
@@ -5,7 +5,7 @@ import type { common_HeroEntityWithTranslations } from "@/api/proto-http/fronten
 
 import { sendHeroEvent } from "@/lib/analitycs/hero";
 import { useTranslationsStore } from "@/lib/stores/translations/store-provider";
-import { calculateAspectRatio, cn, isVideo } from "@/lib/utils";
+import { calculateAspectRatio, cn, internalHref, isVideo } from "@/lib/utils";
 import { AnimatedButton } from "@/components/ui/animated-button";
 import Image from "@/components/ui/image";
 import { Overlay } from "@/components/ui/overlay";
@@ -41,7 +41,7 @@ export function Ads({
             return (
               <div className="relative h-screen w-full" key={i}>
                 <AnimatedButton
-                  href={e.single?.exploreLink || ""}
+                  href={internalHref(e.single?.exploreLink)}
                   className="group relative h-full w-full text-bgColor"
                   onClick={() =>
                     sendHeroEvent({ heroType: "HERO_TYPE_SINGLE" })
@@ -139,7 +139,7 @@ export function Ads({
                 className="relative flex h-full w-full flex-col lg:flex-row"
               >
                 <AnimatedButton
-                  href={e.double?.left?.exploreLink || ""}
+                  href={internalHref(e.double?.left?.exploreLink)}
                   className="group relative h-full w-full text-bgColor"
                   onClick={() =>
                     sendHeroEvent({ heroType: "HERO_TYPE_DOUBLE_LEFT" })
@@ -179,7 +179,7 @@ export function Ads({
                   </div>
                 </AnimatedButton>
                 <AnimatedButton
-                  href={e.double?.right?.exploreLink || ""}
+                  href={internalHref(e.double?.right?.exploreLink)}
                   className="group relative h-full w-full"
                   onClick={() =>
                     sendHeroEvent({ heroType: "HERO_TYPE_DOUBLE_RIGHT" })

--- a/src/app/[locale]/_components/featured-items.tsx
+++ b/src/app/[locale]/_components/featured-items.tsx
@@ -1,6 +1,6 @@
 import { common_Product } from "@/api/proto-http/frontend";
 
-import { cn } from "@/lib/utils";
+import { cn, internalHref } from "@/lib/utils";
 import { AnimatedButton } from "@/components/ui/animated-button";
 import { Carousel } from "@/components/ui/carousel";
 import { Text } from "@/components/ui/text";
@@ -31,7 +31,7 @@ export function FeaturedItems({
       <div className="block lg:hidden">
         <MobileFeaturedItems
           headline={headline}
-          exploreLink={exploreLink ? exploreLink : tag || ""}
+          exploreLink={internalHref(exploreLink ? exploreLink : tag || "")}
           exploreText={exploreText || ""}
           products={products || []}
           itemsQuantity={itemsQuantity}
@@ -51,7 +51,7 @@ export function FeaturedItems({
           <FourFeaturedItems
             products={products}
             headline={headline}
-            href={exploreLink ? exploreLink : tag || ""}
+            href={internalHref(exploreLink ? exploreLink : tag || "")}
             linkText={exploreText || ""}
             onHeroClick={onHeroClick}
           />
@@ -60,7 +60,7 @@ export function FeaturedItems({
           <div className="flex h-full items-center justify-between pl-2.5">
             <HeaderSection
               headline={headline}
-              href={exploreLink ? exploreLink : tag || ""}
+              href={internalHref(exploreLink ? exploreLink : tag || "")}
               linkText={exploreText || ""}
               onHeroClick={onHeroClick}
             />

--- a/src/app/[locale]/_components/main-ads.tsx
+++ b/src/app/[locale]/_components/main-ads.tsx
@@ -9,7 +9,7 @@ import { Overlay } from "@/components/ui/overlay";
 import { Text } from "@/components/ui/text";
 import { sendHeroEvent } from "@/lib/analitycs/hero";
 import { useTranslationsStore } from "@/lib/stores/translations/store-provider";
-import { calculateAspectRatio, isVideo } from "@/lib/utils";
+import { calculateAspectRatio, internalHref, isVideo } from "@/lib/utils";
 
 export function MainAds({
   main,
@@ -33,7 +33,7 @@ export function MainAds({
 
   return (
     <AnimatedButton
-      href={main.single?.exploreLink || ""}
+      href={internalHref(main.single?.exploreLink)}
       className="relative h-screen w-full overflow-hidden"
       onClick={() => sendHeroEvent({ heroType: "HERO_TYPE_MAIN" })}
       onMouseEnter={() => setIsHovered(true)}

--- a/src/app/[locale]/_components/mobile-featured-items.tsx
+++ b/src/app/[locale]/_components/mobile-featured-items.tsx
@@ -1,6 +1,6 @@
 import { common_Product } from "@/api/proto-http/frontend";
 
-import { cn } from "@/lib/utils";
+import { cn, internalHref } from "@/lib/utils";
 import { Carousel } from "@/components/ui/carousel";
 
 import { HeaderSection } from "./featured-items";
@@ -47,7 +47,7 @@ export function MobileFeaturedItems({
       <div className="px-2.5">
         <HeaderSection
           headline={headline}
-          href={isMultipleItems ? exploreLink || "" : itemSlug}
+          href={internalHref(isMultipleItems ? exploreLink || "" : itemSlug)}
           linkText={isMultipleItems ? exploreText || "" : "buy now"}
           onHeroClick={onHeroClick}
         />

--- a/src/lib/utils.tsx
+++ b/src/lib/utils.tsx
@@ -327,3 +327,22 @@ export function resolveLocale(tag: string | undefined) {
   }
   return routing.defaultLocale;
 }
+
+/**
+ * Make an internal nav target root-absolute. Backend-supplied links (hero/ad
+ * `exploreLink`, tags) may be relative (e.g. "catalog"); from /de/en the browser
+ * resolves "catalog" to /de/catalog, dropping the locale and landing on
+ * /de/de/catalog. Forcing a leading slash makes it /catalog -> /de/en/catalog.
+ * External URLs (http:, mailto:, etc.) and anchors are left untouched.
+ */
+export function internalHref(href?: string | null): string {
+  if (!href) return "";
+  if (
+    href.startsWith("/") ||
+    href.startsWith("#") ||
+    /^[a-z][a-z0-9+.-]*:/i.test(href)
+  ) {
+    return href;
+  }
+  return `/${href}`;
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -203,7 +203,14 @@ export default async function middleware(req: NextRequest) {
     const bareCountry = pathname.match(/^\/([A-Za-z]{2})\/?$/);
     if (bareCountry && supportedCountries.includes(bareCountry[1].toLowerCase())) {
         const country = bareCountry[1].toLowerCase();
-        const locale = getLocaleFromCountry(country);
+        // Keep the visitor's chosen language if they have one; only fall back to
+        // the country's default for fresh visitors. Otherwise /de clobbered a
+        // user's NEXT_LOCALE=en and forced /de/de (and the de cookie cascaded to
+        // catalog/product links).
+        const locale =
+            localeCookie && (routing.locales as readonly string[]).includes(localeCookie)
+                ? localeCookie
+                : getLocaleFromCountry(country);
         const url = req.nextUrl.clone();
         url.pathname = `/${country}/${locale}`;
         const res = NextResponse.redirect(url, { status: 307 });


### PR DESCRIPTION
Fixes the `/de/en` → `/de/de/...` language-loss bug (reported when clicking the **hero main** link, which went to `/de/catalog` → `/de/de/catalog`).

## Root cause
Backend-supplied `exploreLink`s (hero/ad/featured) can be **relative** (e.g. `"catalog"`). From `/de/en` (no trailing slash) the browser resolves `"catalog"` to `/de/catalog` — **dropping the locale segment** — and middleware then turns `/de/catalog` into `/de/de/catalog`, clobbering the chosen language.

## Fixes
1. **Relative link normalization (the actual bug)** — new `internalHref()` forces internal targets root-absolute; applied to hero/ad/featured link targets (`main-ads`, `ads`, `featured-items`, `mobile-featured-items`). `"catalog"` → `/catalog` → `/de/en/catalog`. External URLs/anchors untouched; already-absolute slugs are no-ops.
2. **Bare `/{country}` hardening (regression from #616)** — bare `/de` now respects a valid `NEXT_LOCALE` cookie instead of forcing the country default, so it can't reset `en`→`de`.

## Verification
- `internalHref`: `"catalog"`→`/catalog`, `"men"`→`/men`, `/product/..`→unchanged, `https://..`→unchanged.
- Middleware (`next dev`): with `NEXT_LOCALE=en`, `/de`, `/`, `/catalog/men`, `/product/..`, `/account`, `/timeline` → `/de/en/...`; fresh visitor keeps country defaults (`/gb→/gb/en`, `/de→/de/de`, `/fr→/fr/fr`, `/jp→/jp/ja`).
- `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)