### PR TITLE
fix(routing): language preference wins over URL locale (/de/de keeps chosen en)

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -99,6 +99,25 @@ export default async function middleware(req: NextRequest) {
             return NextResponse.redirect(url, { status: 307 });
         }
 
+        // Language preference wins over the URL locale: a visitor who picked a
+        // language (NEXT_LOCALE) keeps it even when opening a /{country}/{otherLocale}
+        // URL — e.g. /de/de after choosing English redirects to /de/en. Deliberate
+        // switches go through from_picker (handled above), which sets the cookie
+        // first, so they don't bounce. New visitors / crawlers (no cookie) get the
+        // URL as-is and the cookie is synced below.
+        if (
+            localeCookie &&
+            localeCookie !== locale &&
+            (routing.locales as readonly string[]).includes(localeCookie)
+        ) {
+            const url = req.nextUrl.clone();
+            url.pathname = `/${country}/${localeCookie}${rest}`;
+            const res = NextResponse.redirect(url, { status: 307 });
+            res.headers.set("Cache-Control", "no-store");
+            setMainCookies(res, country!, localeCookie);
+            return res;
+        }
+
         const url = req.nextUrl.clone();
         url.pathname = `/${locale}${rest}` || "/";
 


### PR DESCRIPTION
Reported: after choosing English on `/de`, opening `/de/de` directly gave German and overwrote the `en` preference.

Per the agreed behavior (**preference > URL**): a visitor with a chosen `NEXT_LOCALE` keeps it even when opening a `/{country}/{otherLocale}` URL.

## Change
In the `/{country}/{locale}` branch, if a valid `NEXT_LOCALE` cookie differs from the URL locale, redirect to `/{country}/{cookieLocale}{rest}` (307) and keep the cookie.

- **Deliberate switches don't bounce:** language/country pickers navigate with `from_picker=1`, handled earlier in middleware, which sets the cookie *before* this branch runs — so switching to German lands on `/de/de` and stays.
- **New visitors / crawlers (no cookie):** URL honored as-is, cookie synced (so shared/indexed `/de/de` still shows German for people without a preference).

## Verification (`next dev`)
| case | result |
|---|---|
| cookie en + `/de/de` | → `/de/en` ✅ |
| cookie en + `/de/en` | 200 (no bounce on refresh) ✅ |
| cookie de + `/de/en` | → `/de/de` ✅ |
| no cookie + `/de/de` | 200 ✅ |
| cookie en + `/de/de/catalog/men` | → `/de/en/catalog/men` ✅ |
| switch→de via `from_picker` | sets de, lands `/de/de` ✅ |
| query params | preserved ✅ |

`tsc` clean. Note: this also corrects the downstream symptom of the relative-href / bare-country issues (#624) — the final `/de/de…` is rewritten back to the chosen locale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)