### PR TITLE
cart: a11y, i18n & brand polish (5 items)

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -840,6 +840,7 @@
   },
   "accessibility": {
     "mobile menu": "grbpwr mobiles menü",
+    "close cart": "warenkorb schließen",
     "notify me dialog": "grbpwr benachrichtige mich",
     "reason label": "grund"
   },

--- a/messages/en.json
+++ b/messages/en.json
@@ -897,6 +897,7 @@
   },
   "accessibility": {
     "mobile menu": "grbpwr mobile menu",
+    "close cart": "close cart",
     "notify me dialog": "grbpwr notify me",
     "reason label": "reason"
   },

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -839,6 +839,7 @@
   },
   "accessibility": {
     "mobile menu": "menu mobile grbpwr",
+    "close cart": "fermer le panier",
     "notify me dialog": "dialogue me notifier grbpwr",
     "reason label": "raison"
   },

--- a/messages/it.json
+++ b/messages/it.json
@@ -839,6 +839,7 @@
   },
   "accessibility": {
     "mobile menu": "menu mobile grbpwr",
+    "close cart": "chiudi carrello",
     "notify me dialog": "dialogo avvisami grbpwr",
     "reason label": "motivo"
   },

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -839,6 +839,7 @@
   },
   "accessibility": {
     "mobile menu": "grbpwrモバイルメニュー",
+    "close cart": "カートを閉じる",
     "notify me dialog": "grbpwr通知ダイアログ",
     "reason label": "理由"
   },

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -839,6 +839,7 @@
   },
   "accessibility": {
     "mobile menu": "grbpwr 모바일 메뉴",
+    "close cart": "장바구니 닫기",
     "notify me dialog": "grbpwr 알림 대화상자",
     "reason label": "이유"
   },

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -839,6 +839,7 @@
   },
   "accessibility": {
     "mobile menu": "grbpwr移动菜单",
+    "close cart": "关闭购物车",
     "notify me dialog": "grbpwr通知对话框",
     "reason label": "原因"
   },

--- a/src/app/[locale]/(checkout)/cart/_components/CartPopup.tsx
+++ b/src/app/[locale]/(checkout)/cart/_components/CartPopup.tsx
@@ -3,12 +3,13 @@
 import { useEffect } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
+import * as DialogPrimitives from "@radix-ui/react-dialog";
 import { useTranslations } from "next-intl";
 
+import { useMediaQuery } from "@/lib/hooks/useMediaQuery";
 import { useCart } from "@/lib/stores/cart/store-provider";
 import { ModalTransition } from "@/components/modal-transition";
 import { Button } from "@/components/ui/button";
-import { Overlay } from "@/components/ui/overlay";
 import { Text } from "@/components/ui/text";
 
 export default function CartPopup({ children }: { children: React.ReactNode }) {
@@ -16,73 +17,74 @@ export default function CartPopup({ children }: { children: React.ReactNode }) {
   const { products, isOpen, closeCart } = useCart((state) => state);
 
   const t = useTranslations("cart");
+  const tAccessibility = useTranslations("accessibility");
+
+  // Gate on desktop so the portaled content never co-opens with the mobile cart
+  // dialog (both read the same store `isOpen`).
+  const isDesktop = useMediaQuery("(min-width: 1024px)");
+  const open = isDesktop && isOpen;
 
   const itemsQuantity = products.length;
   const cartCount = itemsQuantity.toString().padStart(2, "0");
 
   useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        closeCart();
-      }
-    };
-
-    if (isOpen) {
-      window.addEventListener("keydown", handleKeyDown);
-      if (products.length > 0) router.prefetch("/checkout");
+    if (open && products.length > 0) {
+      router.prefetch("/checkout");
     }
-    return () => {
-      window.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [isOpen, closeCart, products.length, router]);
+  }, [open, products.length, router]);
 
   return (
-    <div className="z-50 w-full">
-      <div className="hidden lg:block">
-        {isOpen && (
-          <>
-            <div key="modal-overlay" className="fixed inset-0 z-30">
-              <Overlay
-                cover="screen"
-                onClick={closeCart}
-                disablePointerEvents={false}
-              />
-            </div>
-            <ModalTransition
-              isOpen={isOpen}
-              contentClassName="fixed inset-y-2 right-2 z-30 w-[500px] border border-textInactiveColor bg-bgColor p-2.5 text-textColor"
-              contentSlideFrom="right"
-              content={
-                <div className="flex h-full flex-col gap-y-6">
-                  <div className="flex items-center justify-between">
-                    <Text variant="uppercase">{`${t("shopping cart")} ${itemsQuantity ? `[${cartCount}]` : ""}`}</Text>
-                    <Button onClick={closeCart}>[x]</Button>
-                  </div>
-                  {!itemsQuantity ? (
-                    <div className="flex h-full items-center justify-center">
-                      <Text variant="uppercase">{t("empty")}</Text>
-                    </div>
-                  ) : (
-                    <>{children}</>
-                  )}
-                  {itemsQuantity > 0 && (
-                    <Button
-                      asChild
-                      variant="secondary"
-                      size="lg"
-                      className="block w-full uppercase"
-                    >
-                      <Link href="/checkout" prefetch>
-                        {t("proceed to checkout")}
-                      </Link>
-                    </Button>
-                  )}
+    <DialogPrimitives.Root
+      open={open}
+      onOpenChange={(o) => {
+        if (!o) closeCart();
+      }}
+    >
+      <DialogPrimitives.Portal>
+        <DialogPrimitives.Overlay className="fixed inset-0 z-30 bg-overlay" />
+        <ModalTransition
+          isOpen={open}
+          contentClassName="fixed inset-y-2 right-2 z-30 w-[500px] border border-textInactiveColor bg-bgColor p-2.5 text-textColor"
+          contentSlideFrom="right"
+          content={
+            <DialogPrimitives.Content className="flex h-full min-h-0 flex-col gap-y-6">
+              <DialogPrimitives.Title className="sr-only">
+                {t("shopping cart")}
+              </DialogPrimitives.Title>
+              <div className="flex items-center justify-between">
+                <Text variant="uppercase">{`${t("shopping cart")} ${itemsQuantity ? `[${cartCount}]` : ""}`}</Text>
+                <DialogPrimitives.Close asChild>
+                  <Button
+                    aria-label={tAccessibility("close cart")}
+                    className="flex min-h-11 min-w-11 items-center justify-center"
+                  >
+                    [x]
+                  </Button>
+                </DialogPrimitives.Close>
+              </div>
+              {!itemsQuantity ? (
+                <div className="flex h-full items-center justify-center">
+                  <Text variant="uppercase">{t("empty")}</Text>
                 </div>
-              }
-            />
-          </>
-        )}
-      </div>
-    </div>
+              ) : (
+                <>{children}</>
+              )}
+              {itemsQuantity > 0 && (
+                <Button
+                  asChild
+                  variant="main"
+                  size="lg"
+                  className="block w-full uppercase"
+                >
+                  <Link href="/checkout" prefetch>
+                    {t("proceed to checkout")}
+                  </Link>
+                </Button>
+              )}
+            </DialogPrimitives.Content>
+          }
+        />
+      </DialogPrimitives.Portal>
+    </DialogPrimitives.Root>
   );
 }

--- a/src/app/[locale]/(checkout)/cart/_components/CartPopup.tsx
+++ b/src/app/[locale]/(checkout)/cart/_components/CartPopup.tsx
@@ -54,12 +54,7 @@ export default function CartPopup({ children }: { children: React.ReactNode }) {
               <div className="flex items-center justify-between">
                 <Text variant="uppercase">{`${t("shopping cart")} ${itemsQuantity ? `[${cartCount}]` : ""}`}</Text>
                 <DialogPrimitives.Close asChild>
-                  <Button
-                    aria-label={tAccessibility("close cart")}
-                    className="flex min-h-11 min-w-11 items-center justify-center"
-                  >
-                    [x]
-                  </Button>
+                  <Button aria-label={tAccessibility("close cart")}>[x]</Button>
                 </DialogPrimitives.Close>
               </div>
               {!itemsQuantity ? (

--- a/src/app/[locale]/(checkout)/cart/_components/ItemRow.tsx
+++ b/src/app/[locale]/(checkout)/cart/_components/ItemRow.tsx
@@ -87,10 +87,7 @@ export default function ItemRow({
         </div>
       </div>
       {preorderDate && isDateTodayOrFuture(rawPreorderDate || "") && (
-        <Text
-          variant="uppercase"
-          className="whitespace-nowrap text-textInactiveColor"
-        >
+        <Text variant="uppercase" className="whitespace-nowrap">
           {preorderDate}
         </Text>
       )}
@@ -148,7 +145,7 @@ export default function ItemRow({
           <div className="flex items-center justify-end whitespace-nowrap text-right">
             {isSaleApplied ? (
               <div className="flex items-center gap-x-2">
-                <Text variant="strileTroughInactive">{priceWithoutSale}</Text>
+                <Text variant="strikethrough">{priceWithoutSale}</Text>
                 <Text>{priceWithSale}</Text>
               </div>
             ) : (

--- a/src/app/[locale]/(checkout)/cart/_components/ProductRemoveButton.tsx
+++ b/src/app/[locale]/(checkout)/cart/_components/ProductRemoveButton.tsx
@@ -54,7 +54,7 @@ export default function ProductRemoveButton({
     };
   }, [isRemoveConfirmed, setProductToRemove]);
 
-  const handleRemove = (event: React.PointerEvent) => {
+  const handleRemove = (event: React.MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
     event.stopPropagation();
 
@@ -71,9 +71,10 @@ export default function ProductRemoveButton({
     <div ref={wrapperRef} className="flex justify-end">
       <Button
         type="button"
-        onPointerDown={handleRemove}
+        onClick={handleRemove}
+        aria-live="polite"
         variant="underline"
-        className="min-h-0 min-w-[4.5rem] touch-manipulation self-start p-0 text-right uppercase"
+        className="min-h-11 min-w-[4.5rem] touch-manipulation self-start p-0 text-right uppercase"
       >
         {isRemoveConfirmed ? t("sure?") : t("remove")}
       </Button>

--- a/src/components/flexible-layout.tsx
+++ b/src/components/flexible-layout.tsx
@@ -60,7 +60,7 @@ export default function FlexibleLayout({
       {displayFooter && <Footer theme={theme} accountPanel={accountPanel} />}
       {(headerType === "catalog" || headerType === "main") && (
         <CartPopup>
-          <div className="h-full overflow-y-scroll">
+          <div className="min-h-0 flex-1 overflow-y-auto">
             <CartProductsList />
           </div>
           <CartTotalPrice />

--- a/src/components/ui/mobile-nav-cart.tsx
+++ b/src/components/ui/mobile-nav-cart.tsx
@@ -43,7 +43,7 @@ export function MobileNavCart({
       router.prefetch("/checkout");
     }
   }, [open, products.length, router]);
-  const itemsQuantity = Object.keys(products).length;
+  const itemsQuantity = products.length;
   const cartCount = itemsQuantity.toString().padStart(2, "0");
 
   return (
@@ -73,7 +73,7 @@ export function MobileNavCart({
                   id="mobile-cart-title"
                   className="sr-only"
                 >
-                  {tAccessibility("mobile menu")}
+                  {tCart("shopping cart")}
                 </DialogPrimitives.Title>
                 <div
                   className={cn(
@@ -83,7 +83,13 @@ export function MobileNavCart({
                 >
                   <Text variant="uppercase">{`${tCart("shopping cart")} ${itemsQuantity ? `[${cartCount}]` : ""}`}</Text>
                   <DialogPrimitives.Close asChild>
-                    <Button onClick={closeCart}>[x]</Button>
+                    <Button
+                      onClick={closeCart}
+                      aria-label={tAccessibility("close cart")}
+                      className="flex min-h-11 min-w-11 items-center justify-center"
+                    >
+                      [x]
+                    </Button>
                   </DialogPrimitives.Close>
                 </div>
                 {itemsQuantity > 0 ? (


### PR DESCRIPTION
Part of a 14-PR parallel polish pass over every customer flow (one PR per flow, all branched off `beta`). Each commit is one independently-reviewed plan item: implement → deep code review + fix → commit.

**Scope (`cart`):** accessibility (WCAG: keyboard operability, AA contrast, 44px touch targets, reduced-motion, accessible names), i18n completeness across all 7 locales, and brutalist-brand fidelity (DESIGN.md) — polish that fixes defects without softening the visual language.

**Changes (5):**
- `72fe9e35` fix(cart): render ship-by date and struck price in Ink not #cccccc
- `5ea6298b` a11y(cart): make remove control keyboard-operable with 44px target and armed-state announcement
- `dbdfc55f` fix(cart): keep desktop cart subtotal and checkout CTA on screen
- `35b32ccd` a11y(cart): correct mobile cart dialog title, label close, robust count
- `47fc760f` feat(cart): promote desktop CartPopup to a Radix Dialog

**Verification:** every commit passes `pnpm exec tsc --noEmit` and `pnpm lint` (no new issues on touched files). `pnpm build` compiles, type-checks and lints clean; it stops only at the static-export/prerender step because the backend API is unreachable locally (`ECONNREFUSED`) — a pre-existing condition on `beta`, not introduced here.

**⚠ Sibling-PR conflicts:** these PRs were built in parallel worktrees and edit shared files. Expect merge conflicts when landing more than one, almost all **additive**: `messages/{en,de,fr,it,ja,ko,zh}.json` (touched by 13 of the 14 PRs) and `src/components/ui/toaster.tsx` (5). Merge order matters; later PRs may need a quick rebase on `beta`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
