### PR TITLE
catalog: a11y, i18n & brand polish (7 items)

### DIFF
--- a/src/app/[locale]/_components/product-item.tsx
+++ b/src/app/[locale]/_components/product-item.tsx
@@ -164,14 +164,14 @@ export function ProductItem({
             ) : (
               <>
                 <Text
-                  variant={isSaleApplied ? "strileTroughInactive" : "default"}
+                  variant={isSaleApplied ? "strikethrough" : "default"}
                 >
                   {formattedPrice}
                 </Text>
                 {isSaleApplied && <Text>{formattedPriceWithSale}</Text>}
                 {preorder !== EMPTY_PREORDER &&
                   isDateTodayOrFuture(preorder || "") && (
-                    <Text variant="inactive">{tProduct("preorder")}</Text>
+                    <Text>{tProduct("preorder")}</Text>
                   )}
               </>
             )}

--- a/src/app/[locale]/catalog/_components/FilterOptionButtons.tsx
+++ b/src/app/[locale]/catalog/_components/FilterOptionButtons.tsx
@@ -102,8 +102,9 @@ export default function FilterOptionButtons({
       <Button
         onClick={() => handleClick(factorId)}
         disabled={!isAvailable}
+        aria-pressed={isSelected}
         className={cn(
-          "block border border-transparent uppercase md:hover:border-textColor",
+          "flex min-h-11 items-center border border-transparent uppercase md:hover:border-textColor",
           {
             "border-textColor": isSelected,
           },

--- a/src/app/[locale]/catalog/_components/Sort.tsx
+++ b/src/app/[locale]/catalog/_components/Sort.tsx
@@ -57,7 +57,8 @@ export default function Sort() {
                   );
                 }
               }}
-              className={cn("block", {
+              aria-pressed={isSelected}
+              className={cn("flex min-h-11 items-center", {
                 underline: isSelected,
               })}
             >

--- a/src/app/[locale]/catalog/_components/catalog-skeleton.tsx
+++ b/src/app/[locale]/catalog/_components/catalog-skeleton.tsx
@@ -31,19 +31,13 @@ export function CatalogSkeleton() {
       <div className="hidden flex-col gap-6 px-7 pt-24 lg:flex">
         <div className="sticky top-20 z-10 flex items-start justify-between text-bgColor mix-blend-exclusion">
           <div className="flex items-center gap-2">
-            {TOP_CATEGORIES.map(({ key, label }, index) => {
-              const translated = t(key);
-              const display =
-                key === "loungewear_sleepwear" ? label : translated;
-
-              return (
-                <CategorySkeletonItem
-                  key={key}
-                  display={display}
-                  isLast={index === TOP_CATEGORIES.length - 1}
-                />
-              );
-            })}
+            {TOP_CATEGORIES.map(({ key }, index) => (
+              <CategorySkeletonItem
+                key={key}
+                display={t(key)}
+                isLast={index === TOP_CATEGORIES.length - 1}
+              />
+            ))}
           </div>
           <FilterSkeletonLabel />
         </div>

--- a/src/app/[locale]/catalog/_components/catalog.tsx
+++ b/src/app/[locale]/catalog/_components/catalog.tsx
@@ -46,7 +46,10 @@ export default function Catalog({
   }
 
   return (
-    <>
+    <main>
+      <Text component="h1" className="sr-only">
+        {activeTopCategory || t("title")}
+      </Text>
       <div className="block lg:hidden">
         <MobileCatalog
           firstPageItems={firstPageItems || []}
@@ -75,6 +78,6 @@ export default function Catalog({
           </div>
         )}
       </div>
-    </>
+    </main>
   );
 }

--- a/src/app/[locale]/catalog/_components/filter.tsx
+++ b/src/app/[locale]/catalog/_components/filter.tsx
@@ -1,9 +1,8 @@
+import * as DialogPrimitives from "@radix-ui/react-dialog";
 import { useTranslations } from "next-intl";
 
-import { cn } from "@/lib/utils";
 import { ModalTransition } from "@/components/modal-transition";
 import { Button } from "@/components/ui/button";
-import { Overlay } from "@/components/ui/overlay";
 import { Text } from "@/components/ui/text";
 
 import { Collection } from "./collection";
@@ -21,6 +20,7 @@ export function Filter({
   toggleModal: () => void;
 }) {
   const t = useTranslations("catalog");
+  const tNav = useTranslations("navigation");
 
   const { defaultValue, handleFilterChange } = useFilterQueryParams("size");
   const { defaultValue: sortValue } = useFilterQueryParams("sort");
@@ -56,22 +56,28 @@ export function Filter({
 
   return (
     <div className="z-50 w-full">
-      {isModalOpen && (
-        <div className="hidden lg:block">
-          <Overlay
-            cover="screen"
-            onClick={toggleModal}
-            disablePointerEvents={false}
-          />
+      <DialogPrimitives.Root
+        open={isModalOpen}
+        onOpenChange={(o) => {
+          if (!o) toggleModal();
+        }}
+      >
+        <DialogPrimitives.Portal>
+          <DialogPrimitives.Overlay className="fixed inset-0 z-20 hidden bg-overlay lg:block" />
           <ModalTransition
             isOpen={isModalOpen}
             contentSlideFrom="right"
-            contentClassName="fixed inset-y-2 right-2 z-30 w-[445px] border border-textInactiveColor bg-bgColor p-2.5 text-textColor"
+            contentClassName="fixed inset-y-2 right-2 z-30 hidden w-[445px] border border-textInactiveColor bg-bgColor p-2.5 text-textColor lg:block"
             content={
-              <div className="flex h-full flex-col">
+              <DialogPrimitives.Content className="flex h-full flex-col">
+                <DialogPrimitives.Title className="sr-only">
+                  {t("filter")}
+                </DialogPrimitives.Title>
                 <div className="flex items-center justify-between">
                   <Text variant="uppercase">{t("filter")}</Text>
-                  <Button onClick={toggleModal}>[x]</Button>
+                  <DialogPrimitives.Close asChild>
+                    <Button aria-label={tNav("close")}>[x]</Button>
+                  </DialogPrimitives.Close>
                 </div>
                 <div className="h-full space-y-10 overflow-y-scroll pt-6">
                   <div className="space-y-6">
@@ -83,12 +89,11 @@ export function Filter({
                 </div>
                 <div className="flex items-center justify-end gap-2 bg-bgColor">
                   <Button
-                    className={cn("w-1/2 uppercase", {
-                      block: hasActiveFilters,
-                    })}
+                    className="w-1/2 uppercase"
                     size="lg"
                     variant="simpleReverseWithBorder"
                     onClick={handleClearAll}
+                    disabled={!hasActiveFilters}
                   >
                     {t("clear all")}
                   </Button>
@@ -101,11 +106,11 @@ export function Filter({
                     {t("show")} {total > 0 ? `[${total}]` : ""}
                   </Button>
                 </div>
-              </div>
+              </DialogPrimitives.Content>
             }
           />
-        </div>
-      )}
+        </DialogPrimitives.Portal>
+      </DialogPrimitives.Root>
     </div>
   );
 }

--- a/src/app/[locale]/catalog/_components/mobile-filter.tsx
+++ b/src/app/[locale]/catalog/_components/mobile-filter.tsx
@@ -16,7 +16,7 @@ import { useTotalProducts } from "./useTotalProducts";
 export function MobileFilter() {
   const [open, setOpen] = useState(false);
   const t = useTranslations("catalog");
-  const tAccessibility = useTranslations("accessibility");
+  const tNav = useTranslations("navigation");
 
   const { defaultValue, handleFilterChange } = useFilterQueryParams("size");
   const { defaultValue: sortValue } = useFilterQueryParams("sort");
@@ -68,15 +68,15 @@ export function MobileFilter() {
           content={
             <DialogPrimitives.Content className="flex h-full flex-col">
               <DialogPrimitives.Title className="sr-only">
-                {tAccessibility("mobile menu")}
+                {t("filter")}
               </DialogPrimitives.Title>
               <div className="flex h-full flex-col justify-between">
-                <DialogPrimitives.Close asChild>
-                  <div className="flex items-center justify-between">
-                    <Text variant="uppercase">{t("filter")}</Text>
-                    <Button>[x]</Button>
-                  </div>
-                </DialogPrimitives.Close>
+                <div className="flex items-center justify-between">
+                  <Text variant="uppercase">{t("filter")}</Text>
+                  <DialogPrimitives.Close asChild>
+                    <Button aria-label={tNav("close")}>[x]</Button>
+                  </DialogPrimitives.Close>
+                </div>
                 <div className="h-full space-y-10 overflow-y-scroll pt-10">
                   <div className="space-y-6">
                     <Text variant="uppercase">{t("sort by")}</Text>

--- a/src/app/[locale]/catalog/_components/useFilterSelection.ts
+++ b/src/app/[locale]/catalog/_components/useFilterSelection.ts
@@ -27,19 +27,23 @@ export function useFilterSelection({
             .filter(Boolean);
     };
 
-    const initItems = findInitialItems();
-    const initValues = filterKey === "size"
-        ? initItems.map((item: any) => item?.id?.toString())
-        : initItems.map((item: any) => item?.name);
+    const computeSelectedValues = () => {
+        const initItems = findInitialItems();
+        return filterKey === "size"
+            ? initItems.map((item: any) => item?.id?.toString())
+            : initItems.map((item: any) => item?.name);
+    };
 
-    const [selectedValues, setSelectedValues] = useState<string[]>(initValues);
+    const [selectedValues, setSelectedValues] = useState<string[]>(computeSelectedValues);
 
-    // Sync with URL changes
+    // Re-sync with the URL on every param change (back/forward, cleared filters),
+    // and once the dictionary resolves on a cold deep-link load. Keyed on
+    // `items.length` (a stable primitive) to avoid a re-render loop from `items`'
+    // changing array reference.
     useEffect(() => {
-        if (!defaultValue) {
-            setSelectedValues([]);
-        }
-    }, [defaultValue]);
+        setSelectedValues(computeSelectedValues());
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [defaultValue, items.length]);
 
     const handleToggle = async (value: string) => {
         let newSelected: string[];

--- a/src/app/[locale]/catalog/_components/useScrambleText.ts
+++ b/src/app/[locale]/catalog/_components/useScrambleText.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { FIT_OPTIONS, TOP_CATEGORIES, currencySymbols } from "@/constants";
+import { useReducedMotion } from "framer-motion";
 import { useTranslations } from "next-intl";
 import { useCallback, useEffect, useState } from "react";
 
@@ -24,19 +25,25 @@ function createRandomCurrencyPhrase() {
 function useScrambleAnimation(target: string, shouldRepeat = false) {
     const [display, setDisplay] = useState(target);
     const [cycle, setCycle] = useState(0);
+    const shouldReduceMotion = useReducedMotion();
 
     useEffect(() => {
-        if (!shouldRepeat || !target) return;
+        if (shouldReduceMotion || !shouldRepeat || !target) return;
 
         const id = setInterval(() => {
             setCycle((c) => c + 1);
         }, WORD_CHANGE_INTERVAL_MS);
 
         return () => clearInterval(id);
-    }, [shouldRepeat, target]);
+    }, [shouldReduceMotion, shouldRepeat, target]);
 
     useEffect(() => {
         if (!target) return;
+
+        if (shouldReduceMotion) {
+            setDisplay(target);
+            return;
+        }
 
         let step = 0;
         const intervalId = setInterval(() => {
@@ -62,7 +69,7 @@ function useScrambleAnimation(target: string, shouldRepeat = false) {
         }, SCRAMBLE_INTERVAL_MS);
 
         return () => clearInterval(intervalId);
-    }, [target, cycle]);
+    }, [target, cycle, shouldReduceMotion]);
 
     return display;
 }
@@ -70,16 +77,19 @@ function useScrambleAnimation(target: string, shouldRepeat = false) {
 // Generic hook for auto-updating text
 function useAutoScrambleText(generatePhrase: () => string) {
     const [target, setTarget] = useState("");
+    const shouldReduceMotion = useReducedMotion();
 
     useEffect(() => {
         setTarget(generatePhrase());
+
+        if (shouldReduceMotion) return;
 
         const intervalId = setInterval(() => {
             setTarget(generatePhrase());
         }, WORD_CHANGE_INTERVAL_MS);
 
         return () => clearInterval(intervalId);
-    }, [generatePhrase]);
+    }, [generatePhrase, shouldReduceMotion]);
 
     return useScrambleAnimation(target);
 }
@@ -93,10 +103,7 @@ export function useScrambleText() {
         const fit = getRandomItem(FIT_OPTIONS);
         const category = getRandomItem(TOP_CATEGORIES);
         const translatedFit = tFit(fit);
-        const translatedCategory =
-            category.key === "loungewear_sleepwear"
-                ? category.label
-                : t(category.key);
+        const translatedCategory = t(category.key);
         return `${translatedFit} ${translatedCategory}`;
     }, [t, tFit]);
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -14,6 +14,12 @@
   ::view-transition-new(root) {
     animation: none;
   }
+
+  .animate-threshold,
+  .animate-threshold-highlight,
+  .animate-highlight-flash {
+    animation: none !important;
+  }
 }
 
 @layer base {


### PR DESCRIPTION
Part of a 14-PR parallel polish pass over every customer flow (one PR per flow, all branched off `beta`). Each commit is one independently-reviewed plan item: implement → deep code review + fix → commit.

**Scope (`catalog`):** accessibility (WCAG: keyboard operability, AA contrast, 44px touch targets, reduced-motion, accessible names), i18n completeness across all 7 locales, and brutalist-brand fidelity (DESIGN.md) — polish that fixes defects without softening the visual language.

**Changes (7):**
- `4469c467` a11y(catalog): paint preorder label and struck price in Ink
- `57b28a13` a11y(catalog): give filter chips and sort rows a 44px touch target and pressed state
- `a9ef5596` a11y(catalog): add main landmark and visually-hidden h1 to listing
- `3dae9924` fix(catalog): re-sync selected chips with URL on every param change
- `8dd7bf40` a11y(catalog): honor reduced-motion in skeleton; localize loungewear
- `adf94efc` a11y(catalog): name the mobile filter close button and fix dialog title
- `d6c291f2` a11y(catalog): rebuild desktop filter on Radix Dialog

**Verification:** every commit passes `pnpm exec tsc --noEmit` and `pnpm lint` (no new issues on touched files). `pnpm build` compiles, type-checks and lints clean; it stops only at the static-export/prerender step because the backend API is unreachable locally (`ECONNREFUSED`) — a pre-existing condition on `beta`, not introduced here.

**⚠ Sibling-PR conflicts:** these PRs were built in parallel worktrees and edit shared files. Expect merge conflicts when landing more than one, almost all **additive**: `messages/{en,de,fr,it,ja,ko,zh}.json` (touched by 13 of the 14 PRs) and `src/components/ui/toaster.tsx` (5). Merge order matters; later PRs may need a quick rebase on `beta`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
