### PR TITLE
currency-locale: a11y, i18n & brand polish (8 items)

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -110,6 +110,7 @@
     "change country": "land ändern",
     "text": "Sie versenden derzeit nach {currentCountry} und Ihre Bestellung wird in {currency} abgerechnet.",
     "search location": "suchen nach einem land",
+    "clear search": "suche löschen",
     "language": "sprache",
     "not-found": "entschuldigung, wir konnten keine ergebnisse für ihre suche finden."
   },

--- a/messages/de.json
+++ b/messages/de.json
@@ -310,7 +310,9 @@
     "VGW": "Sehr schonende Wäsche"
   },
   "geo-suggest": {
-    "message": "Wir denken, Sie sind in {country}. Aktualisieren Sie Ihre Standort?"
+    "message": "Wir denken, Sie sind in {country}. Aktualisieren Sie Ihre Standort?",
+    "accept": "Zu {country} wechseln",
+    "dismiss": "Auf {country} bleiben"
   },
   "update_location": {
     "message": "Sie sind derzeit in {currentCountry}. Beim Wechseln von Ländern/Regionen wird Ihr Warenkorb geleert. Sind Sie sicher, dass Sie fortfahren möchten?",

--- a/messages/en.json
+++ b/messages/en.json
@@ -109,6 +109,7 @@
     "change country": "change country",
     "text": "You are currently shipping to {currentCountry} and your order will be billed in {currency}.",
     "search location": "search location",
+    "clear search": "clear search",
     "language": "language",
     "not-found": "sorry, we couldn't find results for your search."
   },

--- a/messages/en.json
+++ b/messages/en.json
@@ -308,7 +308,9 @@
     "VGW": "Very Gentle Wash"
   },
   "geo-suggest": {
-    "message": "We think you are in {country}. Update your location?"
+    "message": "We think you are in {country}. Update your location?",
+    "accept": "switch to {country}",
+    "dismiss": "stay on {country}"
   },
   "update_location": {
     "message": "You are currently shopping on the {currentCountry}. When changing countries/regions your shopping bag will be emptied. Are you sure you want to proceed?",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -309,7 +309,9 @@
     "VGW": "Lavage très délicat"
   },
   "geo-suggest": {
-    "message": "Nous pensons que vous êtes dans {country}. Mettre à jour votre emplacement?"
+    "message": "Nous pensons que vous êtes dans {country}. Mettre à jour votre emplacement?",
+    "accept": "Passer à {country}",
+    "dismiss": "Rester sur {country}"
   },
   "update_location": {
     "message": "Vous êtes actuellement dans {currentCountry}. Lors du changement de pays/région, votre panier sera vidé. Êtes-vous sûr de vouloir continuer?",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -110,6 +110,7 @@
     "change country": "changer de pays",
     "text": "Vous expédiez actuellement vers {currentCountry} et votre commande sera facturée en {currency}.",
     "search location": "rechercher un pays",
+    "clear search": "effacer la recherche",
     "language": "langue",
     "not-found": "désolé, nous n'avons pas trouvé de résultats pour votre recherche."
   },

--- a/messages/it.json
+++ b/messages/it.json
@@ -110,6 +110,7 @@
     "change country": "cambia paese",
     "text": "Stai attualmente spedendo in {currentCountry} e il tuo ordine verrà fatturato in {currency}.",
     "search location": "cerca un paese",
+    "clear search": "cancella ricerca",
     "language": "lingua",
     "not-found": "scusa, non abbiamo trovato risultati per la tua ricerca."
   },

--- a/messages/it.json
+++ b/messages/it.json
@@ -309,7 +309,9 @@
     "VGW": "Lavaggio molto delicato"
   },
   "geo-suggest": {
-    "message": "Pensiamo che tu sia in {country}. Aggiorna il tuo luogo?"
+    "message": "Pensiamo che tu sia in {country}. Aggiorna il tuo luogo?",
+    "accept": "Passa a {country}",
+    "dismiss": "Rimani su {country}"
   },
   "update_location": {
     "message": "Sei attualmente in {currentCountry}. Quando cambi paese/regione, il tuo carrello sarà svuotato. Sei sicuro di voler continuare?",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -110,6 +110,7 @@
     "change country": "国を変更",
     "text": "現在{currentCountry}への配送を行っており、ご注文は{currency}で請求されます。",
     "search location": "国を検索",
+    "clear search": "検索をクリア",
     "language": "言語",
     "not-found": "申し訳ありませんが、検索結果が見つかりませんでした。"
   },

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -309,7 +309,9 @@
     "VGW": "非常に弱い洗濯"
   },
   "geo-suggest": {
-    "message": "あなたは{country}にいると思います。場所を更新しますか？"
+    "message": "あなたは{country}にいると思います。場所を更新しますか？",
+    "accept": "{country}に切り替える",
+    "dismiss": "{country}のままにする"
   },
   "update_location": {
     "message": "あなたは現在{currentCountry}でショッピングしています。国/地域を変更すると、ショッピングカートが空になります。続行してもよろしいですか？",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -309,7 +309,9 @@
     "VGW": "매우 약한 세탁"
   },
   "geo-suggest": {
-    "message": "우리는 당신이 {country}에 있다고 생각합니다. 위치를 업데이트하시겠습니까?"
+    "message": "우리는 당신이 {country}에 있다고 생각합니다. 위치를 업데이트하시겠습니까?",
+    "accept": "{country}(으)로 전환",
+    "dismiss": "{country}에 머무르기"
   },
   "update_location": {
     "message": "당신은 현재 {currentCountry}에서 쇼핑을 하고 있습니다. 국가/지역을 변경하면 쇼핑카트가 비워집니다. 계속하시겠습니까?",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -110,6 +110,7 @@
     "change country": "국가 변경",
     "text": "현재 {currentCountry}로 배송하고 있으며, 주문은 {currency}로 청구됩니다.",
     "search location": "국가 검색",
+    "clear search": "검색 지우기",
     "language": "언어",
     "not-found": "죄송합니다. 검색 결과를 찾을 수 없습니다."
   },

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -309,7 +309,9 @@
     "VGW": "非常温和的水洗"
   },
   "geo-suggest": {
-    "message": "我们认为您在{country}。更新您的位置？"
+    "message": "我们认为您在{country}。更新您的位置？",
+    "accept": "切换到{country}",
+    "dismiss": "留在{country}"
   },
   "update_location": {
     "message": "您当前在{currentCountry}购物。更改国家/地区时，购物车将被清空。您确定要继续吗？",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -110,6 +110,7 @@
     "change country": "更改国家",
     "text": "您目前的配送地址为{currentCountry}，您的订单将以{currency}计费。",
     "search location": "搜索国家",
+    "clear search": "清除搜索",
     "language": "语言",
     "not-found": "抱歉，我们找不到您搜索的结果。"
   },

--- a/src/app/[locale]/_components/CountriesContent.tsx
+++ b/src/app/[locale]/_components/CountriesContent.tsx
@@ -66,6 +66,7 @@ export function CountriesContent({ className }: { className?: string }) {
               <div className="mb-4 space-y-2.5">
                 <Text className="uppercase">{t("language")}</Text>
                 <RadioGroup
+                  aria-label={t("language")}
                   items={languagesForCurrentCountry.map((item, index) => {
                     const isSelected =
                       item.value === LANGUAGE_ID_TO_LOCALE[languageId];

--- a/src/app/[locale]/_components/CountriesContent.tsx
+++ b/src/app/[locale]/_components/CountriesContent.tsx
@@ -103,7 +103,7 @@ export function CountriesContent({ className }: { className?: string }) {
               {filteredCountries.map((country) => (
                 <Button
                   key={`${country.countryCode}-${country.name}-${country.lng}`}
-                  className="flex w-full items-center justify-between px-4"
+                  className="flex min-h-11 w-full items-center justify-between px-4"
                   onClick={() => handleCountrySelect(country)}
                 >
                   <div className="flex items-center gap-3">
@@ -129,7 +129,7 @@ export function CountriesContent({ className }: { className?: string }) {
                 <FieldsGroupContainer
                   key={region}
                   signType="plus-minus"
-                  clickableAreaClassName="h-9 items-start"
+                  clickableAreaClassName="min-h-11 items-start"
                   childrenSpacingClass="pb-4"
                   headerContentGapClass="space-y-2 lg:space-y-1"
                   title={region}
@@ -140,7 +140,7 @@ export function CountriesContent({ className }: { className?: string }) {
                     {countries.map((country) => (
                       <Button
                         key={`${region}-${country.name}-${country.lng}`}
-                        className="group flex w-full items-center justify-between px-4"
+                        className="group flex min-h-11 w-full items-center justify-between px-4"
                         onClick={() => handleCountrySelect(country)}
                       >
                         <div className="flex min-w-0 flex-1 items-center justify-between border-b border-transparent group-hover:border-textColor">

--- a/src/app/[locale]/_components/CountriesContent.tsx
+++ b/src/app/[locale]/_components/CountriesContent.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { COUNTRIES_BY_REGION, LANGUAGE_ID_TO_LOCALE } from "@/constants";
+import * as DialogPrimitives from "@radix-ui/react-dialog";
 import { useTranslations } from "next-intl";
 
 import { useTranslationsStore } from "@/lib/stores/translations/store-provider";
@@ -19,11 +20,11 @@ export function CountriesContent({ className }: { className?: string }) {
   const [openSection, setOpenSection] = useState<number | null>(null);
   const regionsWithCountries = Object.entries(COUNTRIES_BY_REGION);
   const t = useTranslations("countries-popup");
+  const tNav = useTranslations("navigation");
 
   const { filteredCountries, query, searchQuery, handleSearch } =
     useSearchCountries();
-  const { currentCountry, languageId, closeCountryPopup } =
-    useTranslationsStore((s) => s);
+  const { currentCountry, languageId } = useTranslationsStore((s) => s);
   const {
     languagesForCurrentCountry,
     handleChangeLocaleOnly,
@@ -40,8 +41,17 @@ export function CountriesContent({ className }: { className?: string }) {
     <div className={cn("flex h-full flex-col justify-between", className)}>
       <div className="space-y-10 overflow-y-auto">
         <div className="sticky top-0 flex items-center justify-between bg-bgColor">
-          <Text variant="uppercase">{t("change country")}</Text>
-          <Button onClick={closeCountryPopup}>[x]</Button>
+          <DialogPrimitives.Title asChild>
+            <Text variant="uppercase">{t("change country")}</Text>
+          </DialogPrimitives.Title>
+          <DialogPrimitives.Close asChild>
+            <Button
+              aria-label={tNav("close")}
+              className="flex min-h-11 min-w-11 items-center justify-center"
+            >
+              [x]
+            </Button>
+          </DialogPrimitives.Close>
         </div>
 
         <div className="space-y-8">

--- a/src/app/[locale]/_components/CountriesContent.tsx
+++ b/src/app/[locale]/_components/CountriesContent.tsx
@@ -58,7 +58,7 @@ export function CountriesContent({ className }: { className?: string }) {
           <Text className="uppercase">
             {t("text", {
               currentCountry: currentCountry.name,
-              currency: currentCountry.currencyKey || "",
+              currency: currentCountry.currencyKey || "EUR",
             })}
           </Text>
           {languagesForCurrentCountry &&
@@ -109,7 +109,7 @@ export function CountriesContent({ className }: { className?: string }) {
                 >
                   <div className="flex items-center gap-3">
                     <Text className="uppercase">{country.name}</Text>
-                    <Text>{`[${country.currency}]`}</Text>
+                    <Text>{`[${country.currencyKey}]`}</Text>
                   </div>
                   <Text className="uppercase">{country.displayLng}</Text>
                 </Button>
@@ -147,7 +147,7 @@ export function CountriesContent({ className }: { className?: string }) {
                         <div className="flex min-w-0 flex-1 items-center justify-between border-b border-transparent group-hover:border-textColor">
                           <div className="flex items-center gap-2">
                             <Text className="uppercase">{country.name}</Text>
-                            <Text>{`[${country.currency}]`}</Text>
+                            <Text>{`[${country.currencyKey}]`}</Text>
                           </div>
                           <Text className="uppercase">{country.displayLng}</Text>
                         </div>

--- a/src/app/[locale]/_components/CountriesPopup.tsx
+++ b/src/app/[locale]/_components/CountriesPopup.tsx
@@ -1,10 +1,11 @@
 "use client";
 
+import * as DialogPrimitives from "@radix-ui/react-dialog";
+
+import { useMediaQuery } from "@/lib/hooks/useMediaQuery";
 import { useTranslationsStore } from "@/lib/stores/translations/store-provider";
 import { cn } from "@/lib/utils";
 import { useDataContext } from "@/components/contexts/DataContext";
-import { ModalTransition } from "@/components/modal-transition";
-import { Overlay } from "@/components/ui/overlay";
 
 import { CountriesContent } from "./CountriesContent";
 import { MobileCountriesPopup } from "./mobile-countries-popup";
@@ -13,32 +14,30 @@ export function CountriesPopup() {
   const { isOpen, closeCountryPopup } = useTranslationsStore((s) => s);
   const { dictionary } = useDataContext();
   const isWebsiteEnabled = dictionary?.siteEnabled;
+  const isDesktop = useMediaQuery("(min-width: 1024px)");
 
   return (
     <>
       <MobileCountriesPopup />
-      <div className="hidden lg:block">
-        {isOpen && (
-          <>
-            <Overlay
-              cover="screen"
-              onClick={closeCountryPopup}
-              disablePointerEvents={false}
-            />
-            <ModalTransition
-              isOpen={isOpen}
-              contentSlideFrom="right"
-              contentClassName={cn(
-                "fixed inset-y-2 right-2 z-[70] w-[460px] border border-textInactiveColor bg-bgColor p-2.5 text-textColor",
-                {
-                  blackTheme: !isWebsiteEnabled,
-                },
-              )}
-              content={<CountriesContent />}
-            />
-          </>
-        )}
-      </div>
+      <DialogPrimitives.Root
+        open={isDesktop && isOpen}
+        onOpenChange={closeCountryPopup}
+      >
+        <DialogPrimitives.Portal>
+          <DialogPrimitives.Overlay className="fixed inset-0 z-20 bg-overlay data-[state=open]:animate-modal-fade-in data-[state=closed]:animate-modal-fade-out" />
+          <DialogPrimitives.Content
+            aria-describedby={undefined}
+            className={cn(
+              "fixed inset-y-2 right-2 z-[70] w-[460px] overflow-y-auto border border-textInactiveColor bg-bgColor p-2.5 text-textColor data-[state=open]:animate-modal-fade-in data-[state=closed]:animate-modal-fade-out",
+              {
+                blackTheme: !isWebsiteEnabled,
+              },
+            )}
+          >
+            <CountriesContent />
+          </DialogPrimitives.Content>
+        </DialogPrimitives.Portal>
+      </DialogPrimitives.Root>
     </>
   );
 }

--- a/src/app/[locale]/_components/footer.tsx
+++ b/src/app/[locale]/_components/footer.tsx
@@ -2,11 +2,7 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
-import {
-  currencySymbols,
-  FOOTER_YEAR,
-  FOOTER_LINKS as links,
-} from "@/constants";
+import { FOOTER_YEAR, FOOTER_LINKS as links } from "@/constants";
 import { useTranslations } from "next-intl";
 
 import { useAccountOnboardingStore } from "@/lib/stores/account-onboarding/store-provider";
@@ -122,7 +118,7 @@ export function Footer({
             onClick={openCountryPopup}
           >
             {t("country")}: {currentCountry.name} /{" "}
-            {currencySymbols[currentCountry.currencyKey || "EUR"]}
+            {currentCountry.currencyKey || "EUR"}
           </Button>
           <MobileCountriesPopupTrigger />
         </div>

--- a/src/app/[locale]/_components/mobile-countries-popup.tsx
+++ b/src/app/[locale]/_components/mobile-countries-popup.tsx
@@ -104,7 +104,7 @@ export function MobileCountriesPopup() {
                 {filteredCountries.map((country) => (
                   <Button
                     key={`${country.countryCode}-${country.name}-${country.lng}`}
-                    className="flex w-full items-center justify-between px-3"
+                    className="flex min-h-11 w-full items-center justify-between px-3"
                     onClick={() => handleCountrySelect(country)}
                   >
                     <div className="flex items-center gap-2">
@@ -130,7 +130,7 @@ export function MobileCountriesPopup() {
                   <FieldsGroupContainer
                     key={region}
                     signType="plus-minus"
-                    clickableAreaClassName="h-9 items-start"
+                    clickableAreaClassName="min-h-11 items-start"
                     childrenSpacingClass="pb-4"
                     title={region}
                     isOpen={openSection === index}
@@ -140,7 +140,7 @@ export function MobileCountriesPopup() {
                       {countries.map((country) => (
                         <Button
                           key={`${region}-${country.name}-${country.lng}`}
-                          className="flex w-full items-center justify-between px-3"
+                          className="flex min-h-11 w-full items-center justify-between px-3"
                           onClick={() => handleCountrySelect(country)}
                         >
                           <div className="flex items-center gap-2">

--- a/src/app/[locale]/_components/mobile-countries-popup.tsx
+++ b/src/app/[locale]/_components/mobile-countries-popup.tsx
@@ -103,7 +103,7 @@ export function MobileCountriesPopup() {
             />
           </div>
 
-          <div className="space-y-4 text-textColor">
+          <div className="mt-8 space-y-4 text-textColor">
             {searchQuery ? (
               <div className="flex flex-col gap-2">
                 {filteredCountries.map((country) => (

--- a/src/app/[locale]/_components/mobile-countries-popup.tsx
+++ b/src/app/[locale]/_components/mobile-countries-popup.tsx
@@ -44,6 +44,7 @@ export function MobileCountriesPopup() {
   });
 
   const t = useTranslations("countries-popup");
+  const tNav = useTranslations("navigation");
 
   function toggleSection(index: number) {
     setOpenSection((prev) => (prev === index ? null : index));
@@ -54,7 +55,7 @@ export function MobileCountriesPopup() {
       <DialogPrimitives.Portal>
         <DialogPrimitives.Overlay className="data-[state=open]:animate-overlay-in data-[state=closed]:animate-overlay-out fixed inset-0 z-20 h-screen bg-overlay" />
         <DialogPrimitives.Content
-          onOpenAutoFocus={(e) => e.preventDefault()}
+          aria-describedby={undefined}
           className={cn(
             "data-[state=open]:animate-panel-in data-[state=closed]:animate-panel-out fixed inset-x-2 bottom-2 top-2 z-[70] flex flex-col overflow-y-auto border border-textInactiveColor bg-bgColor p-2.5 text-textColor lg:hidden",
             {
@@ -63,9 +64,16 @@ export function MobileCountriesPopup() {
           )}
         >
           <div className="flex items-center justify-between bg-bgColor pb-8">
-            <Text variant="uppercase">{t("change country")}</Text>
+            <DialogPrimitives.Title asChild>
+              <Text variant="uppercase">{t("change country")}</Text>
+            </DialogPrimitives.Title>
             <DialogPrimitives.Close asChild>
-              <Button>[x]</Button>
+              <Button
+                aria-label={tNav("close")}
+                className="flex min-h-11 min-w-11 items-center justify-center"
+              >
+                [x]
+              </Button>
             </DialogPrimitives.Close>
           </div>
 
@@ -76,19 +84,20 @@ export function MobileCountriesPopup() {
                 currency: currentCountry.currencyKey || "EUR",
               })}
             </Text>
-            <div className="mb-4 space-y-2.5">
-              <Text className="uppercase">{t("language")}</Text>
-              {languagesForCurrentCountry &&
-                languagesForCurrentCountry.length > 1 && (
+            {languagesForCurrentCountry &&
+              languagesForCurrentCountry.length > 1 && (
+                <div className="mb-4 space-y-2.5">
+                  <Text className="uppercase">{t("language")}</Text>
                   <RadioGroup
+                    aria-label={t("language")}
                     items={languagesForCurrentCountry}
                     name="language-selector"
                     value={LANGUAGE_ID_TO_LOCALE[languageId]}
                     onValueChange={(val: string) => handleChangeLocaleOnly(val)}
                     className="flex flex-col gap-2 uppercase"
                   />
-                )}
-            </div>
+                </div>
+              )}
             <Searchbar
               name="search"
               value={query}

--- a/src/app/[locale]/_components/mobile-countries-popup.tsx
+++ b/src/app/[locale]/_components/mobile-countries-popup.tsx
@@ -49,11 +49,11 @@ export function MobileCountriesPopup() {
   return (
     <DialogPrimitives.Root open={open} onOpenChange={closeCountryPopup}>
       <DialogPrimitives.Portal>
-        <DialogPrimitives.Overlay className="data-[state=open]:animate-overlay-in data-[state=closed]:animate-overlay-out fixed inset-0 z-20 h-screen bg-overlay" />
+        <DialogPrimitives.Overlay className="data-[state=open]:animate-modal-fade-in data-[state=closed]:animate-modal-fade-out fixed inset-0 z-20 h-screen bg-overlay" />
         <DialogPrimitives.Content
           aria-describedby={undefined}
           className={cn(
-            "data-[state=open]:animate-panel-in data-[state=closed]:animate-panel-out fixed inset-x-2 bottom-2 top-2 z-[70] flex flex-col overflow-y-auto border border-textInactiveColor bg-bgColor p-2.5 text-textColor lg:hidden",
+            "data-[state=open]:animate-modal-fade-in data-[state=closed]:animate-modal-fade-out fixed inset-x-2 bottom-2 top-2 z-[70] flex flex-col overflow-y-auto border border-textInactiveColor bg-bgColor p-2.5 text-textColor lg:hidden",
             {
               blackTheme: !isWebsiteEnabled,
             },

--- a/src/app/[locale]/_components/mobile-countries-popup.tsx
+++ b/src/app/[locale]/_components/mobile-countries-popup.tsx
@@ -1,11 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import {
-  COUNTRIES_BY_REGION,
-  currencySymbols,
-  LANGUAGE_ID_TO_LOCALE,
-} from "@/constants";
+import { COUNTRIES_BY_REGION, LANGUAGE_ID_TO_LOCALE } from "@/constants";
 import * as DialogPrimitives from "@radix-ui/react-dialog";
 import { useTranslations } from "next-intl";
 
@@ -118,7 +114,7 @@ export function MobileCountriesPopup() {
                   >
                     <div className="flex items-center gap-2">
                       <Text className="uppercase">{country.name}</Text>
-                      <Text>{`[${country.currency}]`}</Text>
+                      <Text>{`[${country.currencyKey}]`}</Text>
                     </div>
                     <Text className="uppercase">{country.displayLng}</Text>
                   </Button>
@@ -154,7 +150,7 @@ export function MobileCountriesPopup() {
                         >
                           <div className="flex items-center gap-2">
                             <Text className="uppercase">{country.name}</Text>
-                            <Text>{`[${country.currency}]`}</Text>
+                            <Text>{`[${country.currencyKey}]`}</Text>
                           </div>
                           <Text className="uppercase">
                             {country.displayLng}
@@ -186,8 +182,7 @@ export function MobileCountriesPopupTrigger() {
     >
       <Text>{f("country")}:</Text>
       <Text>
-        {currentCountry.name} /{" "}
-        {currencySymbols[currentCountry.currencyKey || "EUR"]}
+        {currentCountry.name} / {currentCountry.currencyKey || "EUR"}
       </Text>
     </Button>
   );

--- a/src/components/ui/geo-suggest-banner.tsx
+++ b/src/components/ui/geo-suggest-banner.tsx
@@ -172,7 +172,7 @@ export function GeoSuggestBanner({
             variant="main"
             onClick={onAccept}
           >
-            {suggestedCountryName}
+            {t("accept", { country: suggestedCountryName || "" })}
           </Button>
           <Button
             size="lg"
@@ -180,7 +180,7 @@ export function GeoSuggestBanner({
             variant="simpleReverse"
             onClick={onDismiss}
           >
-            {currentCountryName}
+            {t("dismiss", { country: currentCountryName || "" })}
           </Button>
         </div>
       </div>

--- a/src/components/ui/searchbar.tsx
+++ b/src/components/ui/searchbar.tsx
@@ -1,7 +1,5 @@
 import { useTranslations } from "next-intl";
 
-import { cn } from "@/lib/utils";
-
 import { Button } from "./button";
 import Input, { InputProps } from "./input";
 import { Text } from "./text";
@@ -20,6 +18,7 @@ export function Searchbar({ value, noFound, handleSearch, ...props }: Props) {
         <div className="flex-1">
           <Input
             value={value}
+            aria-label={t("search location")}
             className="cursor-pointer border-none uppercase"
             autoComplete="off"
             autoCorrect="off"
@@ -31,6 +30,9 @@ export function Searchbar({ value, noFound, handleSearch, ...props }: Props) {
           />
         </div>
         <Button
+          aria-label={t("clear search")}
+          aria-hidden={!value}
+          tabIndex={value ? 0 : -1}
           className={`transform transition-[transform,opacity] duration-200 ease-out ${
             value
               ? "scale-100 opacity-100"
@@ -42,16 +44,13 @@ export function Searchbar({ value, noFound, handleSearch, ...props }: Props) {
         </Button>
       </div>
 
-      <Text
-        className={cn(
-          "border border-textInactiveColor px-4 py-1 opacity-0 transition-opacity duration-200 ease-in-out",
-          {
-            "opacity-100": value && noFound,
-          },
+      <div role="status" aria-live="polite">
+        {value && noFound && (
+          <Text className="border border-textInactiveColor px-4 py-1">
+            {t("not-found")}
+          </Text>
         )}
-      >
-        {t("not-found")}
-      </Text>
+      </div>
     </div>
   );
 }

--- a/src/components/ui/update-location.tsx
+++ b/src/components/ui/update-location.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { usePathname } from "next/navigation";
 import { LANGUAGE_ID_TO_LOCALE } from "@/constants";
 import { useTranslations } from "next-intl";
@@ -28,6 +28,7 @@ export function UpdateLocation() {
     cancelNextCountry,
   } = useTranslationsStore((state) => state);
   const t = useTranslations("update_location");
+  const [isApplying, setIsApplying] = useState(false);
   const pathname = usePathname();
   const isCheckoutPage = /\/checkout(?:\/|$)/.test(pathname || "");
   const targetLocale =
@@ -62,6 +63,8 @@ export function UpdateLocation() {
       nextCountry.localeCode || LANGUAGE_ID_TO_LOCALE[languageId];
 
     if (!targetCountryCode || !newLocale) return;
+
+    setIsApplying(true);
 
     if (targetCountryCode) {
       const selectedSavedAddressId = Number(nextCountry.savedAddressId);
@@ -128,6 +131,8 @@ export function UpdateLocation() {
               variant="main"
               size="lg"
               className="w-full uppercase"
+              loading={isApplying}
+              disabled={isApplying}
               onClick={() => {
                 void handleApplyCountry();
               }}
@@ -139,6 +144,7 @@ export function UpdateLocation() {
               variant="simpleReverse"
               size="lg"
               className="w-full uppercase"
+              disabled={isApplying}
               onClick={handleCancelCountry}
             >
               {t("cancel")}


### PR DESCRIPTION
Part of a 14-PR parallel polish pass over every customer flow (one PR per flow, all branched off `beta`). Each commit is one independently-reviewed plan item: implement → deep code review + fix → commit.

**Scope (`currency-locale`):** accessibility (WCAG: keyboard operability, AA contrast, 44px touch targets, reduced-motion, accessible names), i18n completeness across all 7 locales, and brutalist-brand fidelity (DESIGN.md) — polish that fixes defects without softening the visual language.

**Changes (8):**
- `300a5da6` a11y(currency-locale): rebuild desktop country popup on Radix Dialog
- `61f4e126` a11y(currency-locale): meet 44px touch target on country rows and accordion headers
- `dd4bfbbc` a11y(currency-locale): label language picker, fix mobile dialog title/close/focus
- `9951aa5d` a11y(currency-locale): expose search field, clear button, and no-results to assistive tech
- `3006f670` feat(currency-locale): use verb+object labels on geo-suggest banner
- `7a75b41b` feat(currency-locale): show busy state on UpdateLocation Continue during apply
- `0d22ad13` refactor(currency-locale): show currency as ISO code across popup and footer
- `2804a045` fix(currency-locale): resolve mobile dialog animation to real keyframes

**Verification:** every commit passes `pnpm exec tsc --noEmit` and `pnpm lint` (no new issues on touched files). `pnpm build` compiles, type-checks and lints clean; it stops only at the static-export/prerender step because the backend API is unreachable locally (`ECONNREFUSED`) — a pre-existing condition on `beta`, not introduced here.

**⚠ Sibling-PR conflicts:** these PRs were built in parallel worktrees and edit shared files. Expect merge conflicts when landing more than one, almost all **additive**: `messages/{en,de,fr,it,ja,ko,zh}.json` (touched by 13 of the 14 PRs) and `src/components/ui/toaster.tsx` (5). Merge order matters; later PRs may need a quick rebase on `beta`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
