### PR TITLE
home: a11y, i18n & brand polish (8 items)

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -137,6 +137,7 @@
   },
   "catalog": {
     "title": "katalog",
+    "buy now": "jetzt kaufen",
     "sort by": "sortieren nach",
     "size": "größe",
     "shoe size": "schuhgröße",

--- a/messages/de.json
+++ b/messages/de.json
@@ -421,7 +421,8 @@
     "objects description": "entdecken Sie GRBPWR Objekte und Accessoires. Taschen, Lederwaren und Lifestyle-Artikel.",
     "timeline": "zeitleiste",
     "timeline description": "archiv und updates entdecken",
-    "main hero image": "hauptheldenbild"
+    "main hero image": "hauptheldenbild",
+    "archive image": "archivbild"
   },
   "order-status": {
     "order status": "Bestellstatus",

--- a/messages/en.json
+++ b/messages/en.json
@@ -419,7 +419,8 @@
     "objects description": "explore GRBPWR objects and accessories. bags, small leather goods, and lifestyle pieces.",
     "timeline": "timeline",
     "timeline description": "discover archive and updates",
-    "main hero image": "main hero image"
+    "main hero image": "main hero image",
+    "archive image": "archive image"
   },
   "order-status": {
     "order status": "order status",

--- a/messages/en.json
+++ b/messages/en.json
@@ -136,6 +136,7 @@
   },
   "catalog": {
     "title": "catalog",
+    "buy now": "buy now",
     "sort by": "sort by",
     "size": "size",
     "shoe size": "shoe size",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -420,7 +420,8 @@
     "objects description": "explorez les objets et accessoires GRBPWR. sacs, maroquinerie et pièces lifestyle.",
     "timeline": "chronologie",
     "timeline description": "découvrir l'archive et les mises à jour",
-    "main hero image": "image héroïque principale"
+    "main hero image": "image héroïque principale",
+    "archive image": "image d'archive"
   },
   "order-status": {
     "order status": "statut de commande",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -137,6 +137,7 @@
   },
   "catalog": {
     "title": "catalogue",
+    "buy now": "acheter",
     "sort by": "trier par",
     "size": "taille",
     "shoe size": "taille de chaussure",

--- a/messages/it.json
+++ b/messages/it.json
@@ -137,6 +137,7 @@
   },
   "catalog": {
     "title": "catalogo",
+    "buy now": "acquista",
     "sort by": "ordina per",
     "size": "taglia",
     "shoe size": "taglia scarpa",

--- a/messages/it.json
+++ b/messages/it.json
@@ -420,7 +420,8 @@
     "objects description": "esplora oggetti e accessori GRBPWR. borse, piccola pelletteria e pezzi lifestyle.",
     "timeline": "cronologia",
     "timeline description": "scopri l'archivio e le aggiornamenti",
-    "main hero image": "immagine hero principale"
+    "main hero image": "immagine hero principale",
+    "archive image": "immagine d'archivio"
   },
   "order-status": {
     "order status": "stato dell'ordine",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -137,6 +137,7 @@
   },
   "catalog": {
     "title": "カタログ",
+    "buy now": "今すぐ購入",
     "sort by": "並び替え",
     "size": "サイズ",
     "shoe size": "シューズサイズ",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -420,7 +420,8 @@
     "objects description": "GRBPWRのオブジェクトとアクセサリーをご覧ください。バッグ、革小物、ライフスタイルアイテム。",
     "timeline": "タイムライン",
     "timeline description": "アーカイブと更新を発見",
-    "main hero image": "メインヒーロー画像"
+    "main hero image": "メインヒーロー画像",
+    "archive image": "アーカイブ画像"
   },
   "order-status": {
     "order status": "注文状況",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -137,6 +137,7 @@
   },
   "catalog": {
     "title": "카탈로그",
+    "buy now": "지금 구매",
     "sort by": "정렬",
     "size": "사이즈",
     "shoe size": "신발 사이즈",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -420,7 +420,8 @@
     "objects description": "GRBPWR 오브젝트와 악세서리를 탐색하세요. 가방, 소가죽 제품, 라이프스타일 피스.",
     "timeline": "타임라인",
     "timeline description": "아카이브와 업데이트 발견",
-    "main hero image": "메인 히어로 이미지"
+    "main hero image": "메인 히어로 이미지",
+    "archive image": "아카이브 이미지"
   },
   "order-status": {
     "order status": "주문 상태",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -420,7 +420,8 @@
     "objects description": "探索GRBPWR物件与配饰。包袋、皮具及生活方式单品。",
     "timeline": "时间轴",
     "timeline description": "发现档案和更新",
-    "main hero image": "主英雄图片"
+    "main hero image": "主英雄图片",
+    "archive image": "存档图片"
   },
   "order-status": {
     "order status": "订单状态",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -137,6 +137,7 @@
   },
   "catalog": {
     "title": "目录",
+    "buy now": "立即购买",
     "sort by": "排序",
     "size": "尺码",
     "shoe size": "鞋码",

--- a/src/app/[locale]/_components/ads.tsx
+++ b/src/app/[locale]/_components/ads.tsx
@@ -167,7 +167,7 @@ export function Ads({
                     }
                     autoPlay={isMobile && isLeftVideo}
                   />
-                  <div className="absolute inset-0 z-20 flex flex-col items-center justify-center space-y-6">
+                  <div className="absolute inset-0 z-20 flex flex-col items-center justify-center space-y-6 mix-blend-exclusion">
                     <Text
                       variant="uppercase"
                       className={cn({
@@ -207,7 +207,7 @@ export function Ads({
                     }
                     autoPlay={isMobile && isRightVideo}
                   />
-                  <div className="absolute inset-0 z-20 flex flex-col items-center justify-center space-y-6 text-bgColor">
+                  <div className="absolute inset-0 z-20 flex flex-col items-center justify-center space-y-6 text-bgColor mix-blend-exclusion">
                     <Text
                       variant="uppercase"
                       className={cn({

--- a/src/app/[locale]/_components/ads.tsx
+++ b/src/app/[locale]/_components/ads.tsx
@@ -59,7 +59,7 @@ export function Ads({
                         ""
                       }
                       blurhash={e.single?.mediaLandscape?.media?.blurhash}
-                      alt={currentTranslation?.headline || "GRBPWR feature"}
+                      alt={currentTranslation?.headline || ""}
                       aspectRatio={calculateAspectRatio(
                         e.single?.mediaLandscape?.media?.thumbnail?.width,
                         e.single?.mediaLandscape?.media?.thumbnail?.height,
@@ -84,7 +84,7 @@ export function Ads({
                         e.single?.mediaPortrait?.media?.fullSize?.mediaUrl || ""
                       }
                       blurhash={e.single?.mediaPortrait?.media?.blurhash}
-                      alt={currentTranslation?.headline || "GRBPWR feature"}
+                      alt={currentTranslation?.headline || ""}
                       aspectRatio={calculateAspectRatio(
                         e.single?.mediaPortrait?.media?.fullSize?.width,
                         e.single?.mediaPortrait?.media?.fullSize?.height,
@@ -153,7 +153,7 @@ export function Ads({
                   <Image
                     src={leftUrl}
                     blurhash={e.double?.left?.mediaLandscape?.media?.blurhash}
-                    alt={leftTranslation?.headline || "GRBPWR feature"}
+                    alt={leftTranslation?.headline || ""}
                     aspectRatio={calculateAspectRatio(
                       e.double?.left?.mediaLandscape?.media?.thumbnail?.width,
                       e.double?.left?.mediaLandscape?.media?.thumbnail?.height,
@@ -193,7 +193,7 @@ export function Ads({
                   <Image
                     src={rightUrl}
                     blurhash={e.double?.right?.mediaLandscape?.media?.blurhash}
-                    alt={rightTranslation?.headline || "GRBPWR feature"}
+                    alt={rightTranslation?.headline || ""}
                     aspectRatio={calculateAspectRatio(
                       e.double?.right?.mediaLandscape?.media?.thumbnail?.width,
                       e.double?.right?.mediaLandscape?.media?.thumbnail?.height,

--- a/src/app/[locale]/_components/archive-item.tsx
+++ b/src/app/[locale]/_components/archive-item.tsx
@@ -5,7 +5,6 @@ import type { common_ArchiveFull } from "@/api/proto-http/frontend";
 import { calculateAspectRatio, cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import Image from "@/components/ui/image";
-import { Text } from "@/components/ui/text";
 
 export function ArchiveItem({
   archive,
@@ -22,7 +21,7 @@ export function ArchiveItem({
           className={cn("flex h-full w-full")}
           href={archive?.archiveList?.slug || ""}
         >
-          {archive?.media?.map((m, id) => (
+          {archive?.media?.map((m) => (
             <div key={m.id} className={cn("group relative", className)}>
               <Image
                 src={m.media?.fullSize?.mediaUrl || ""}
@@ -33,9 +32,6 @@ export function ArchiveItem({
                 )}
                 fit="contain"
               />
-              <Text className="absolute right-4 top-1/2 block -translate-y-1/2 md:hidden md:group-hover:block">
-                {id}
-              </Text>
             </div>
           ))}
         </Link>

--- a/src/app/[locale]/_components/archive-item.tsx
+++ b/src/app/[locale]/_components/archive-item.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { useTranslations } from "next-intl";
 import type { common_ArchiveFull } from "@/api/proto-http/frontend";
 
 import { calculateAspectRatio, cn } from "@/lib/utils";
@@ -13,6 +14,7 @@ export function ArchiveItem({
   archive: common_ArchiveFull | undefined;
   className: string;
 }) {
+  const t = useTranslations("meta");
   return (
     <div className="relative">
       <Button asChild>
@@ -24,7 +26,7 @@ export function ArchiveItem({
             <div key={m.id} className={cn("group relative", className)}>
               <Image
                 src={m.media?.fullSize?.mediaUrl || ""}
-                alt="archive item"
+                alt={t("archive image")}
                 aspectRatio={calculateAspectRatio(
                   m.media?.fullSize?.width,
                   m.media?.fullSize?.height,

--- a/src/app/[locale]/_components/featured-items.tsx
+++ b/src/app/[locale]/_components/featured-items.tsx
@@ -132,7 +132,7 @@ export function HeaderSection({
         <AnimatedButton
           href={href}
           animationArea="text"
-          className="flex flex-wrap items-center gap-2 uppercase lg:flex-nowrap lg:pl-2.5"
+          className="flex min-h-11 flex-wrap items-center gap-2 uppercase lg:min-h-0 lg:flex-nowrap lg:pl-2.5"
           onClick={onHeroClick}
         >
           <Text className="text-wrap">{headline}</Text>

--- a/src/app/[locale]/_components/hero-archive.tsx
+++ b/src/app/[locale]/_components/hero-archive.tsx
@@ -37,7 +37,10 @@ export function HeroArchive({
       ) {
         container.scrollTo({
           left: 250,
-          behavior: "smooth",
+          behavior: window.matchMedia("(prefers-reduced-motion: reduce)")
+            .matches
+            ? "auto"
+            : "smooth",
         });
         hasScrolledRef.current = true;
       }

--- a/src/app/[locale]/_components/main-ads.tsx
+++ b/src/app/[locale]/_components/main-ads.tsx
@@ -82,8 +82,8 @@ export function MainAds({
       </div>
       <div className="block h-full lg:hidden">{children}</div>
       <Overlay cover="container" />
-      <div className="absolute inset-x-0 top-32 z-20 flex h-screen items-center lg:top-20">
-        <div className="flex w-full flex-col items-start gap-6 p-2 text-bgColor md:flex-row md:justify-between">
+      <div className="absolute inset-0 z-20 flex items-center">
+        <div className="flex w-full flex-col items-start gap-6 p-2 pt-12 text-bgColor md:flex-row md:justify-between lg:pt-16">
           <Text variant="uppercase">{currentTranslation?.tag}</Text>
           <Text variant="uppercase" component="h1">
             {currentTranslation?.headline}

--- a/src/app/[locale]/_components/main-ads.tsx
+++ b/src/app/[locale]/_components/main-ads.tsx
@@ -53,9 +53,7 @@ export function MainAds({
             main.single?.mediaLandscape?.media?.fullSize?.height,
           )}
           alt={
-            currentTranslation?.headline ||
-            currentTranslation?.tag ||
-            "GRBPWR"
+            currentTranslation?.headline || currentTranslation?.tag || ""
           }
           fit="cover"
           priority={true}
@@ -73,9 +71,7 @@ export function MainAds({
             mobileMedia?.fullSize?.height,
           )}
           alt={
-            currentTranslation?.headline ||
-            currentTranslation?.tag ||
-            "GRBPWR"
+            currentTranslation?.headline || currentTranslation?.tag || ""
           }
           fit="cover"
           priority={true}

--- a/src/app/[locale]/_components/mobile-featured-items.tsx
+++ b/src/app/[locale]/_components/mobile-featured-items.tsx
@@ -1,3 +1,4 @@
+import { useTranslations } from "next-intl";
 import { common_Product } from "@/api/proto-http/frontend";
 
 import { cn, internalHref } from "@/lib/utils";
@@ -21,6 +22,7 @@ export function MobileFeaturedItems({
   itemsQuantity: number;
   onHeroClick?: () => void;
 }) {
+  const tCatalog = useTranslations("catalog");
   const isMultipleItems = itemsQuantity > 1;
   const itemSlug = products?.[0]?.slug || "";
   const needsCarousel = itemsQuantity === 3 || itemsQuantity > 4;
@@ -48,7 +50,7 @@ export function MobileFeaturedItems({
         <HeaderSection
           headline={headline}
           href={internalHref(isMultipleItems ? exploreLink || "" : itemSlug)}
-          linkText={isMultipleItems ? exploreText || "" : "buy now"}
+          linkText={isMultipleItems ? exploreText || "" : tCatalog("buy now")}
           onHeroClick={onHeroClick}
         />
       </div>

--- a/src/app/[locale]/_components/product-item.tsx
+++ b/src/app/[locale]/_components/product-item.tsx
@@ -113,7 +113,7 @@ export function ProductItem({
           // unmounts, clearing it). Only a scroll/drag (pointercancel) clears it.
           onPointerCancel={onPressEnd}
           className={cn("relative", {
-            "group-data-[held=true]:animate-threshold-highlight":
+            "motion-safe:group-data-[held=true]:animate-threshold-highlight":
               !disableAnimations,
           })}
         >

--- a/src/app/[locale]/_components/product-item.tsx
+++ b/src/app/[locale]/_components/product-item.tsx
@@ -171,7 +171,7 @@ export function ProductItem({
                 {isSaleApplied && <Text>{formattedPriceWithSale}</Text>}
                 {preorder !== EMPTY_PREORDER &&
                   isDateTodayOrFuture(preorder || "") && (
-                    <Text variant="inactive">{tProduct("preorder")}</Text>
+                    <Text variant="uppercase">{tProduct("preorder")}</Text>
                   )}
               </>
             )}

--- a/src/app/[locale]/_components/single-featured-item.tsx
+++ b/src/app/[locale]/_components/single-featured-item.tsx
@@ -1,5 +1,5 @@
-import { useState } from "react";
 import Link from "next/link";
+import { useTranslations } from "next-intl";
 import { common_Product } from "@/api/proto-http/frontend";
 import { currencySymbols } from "@/constants";
 
@@ -45,7 +45,7 @@ export function SingleFeaturedItem({
 }) {
   const { languageId } = useTranslationsStore((state) => state);
   const { currentCountry } = useTranslationsStore((state) => state);
-  const [isHovered, setIsHovered] = useState(false);
+  const tCatalog = useTranslations("catalog");
 
   const currencyKey = currentCountry.currencyKey || "EUR";
 
@@ -104,20 +104,19 @@ export function SingleFeaturedItem({
                     </Text>
                   )}
                 </div>
-                <Text
-                  variant={isHovered ? "underlined" : "default"}
-                  className="whitespace-nowrap uppercase"
+                <Button
+                  variant="default"
+                  asChild
+                  className="whitespace-nowrap uppercase hover:underline focus-visible:underline"
                 >
-                  buy now
-                </Text>
+                  <Link href={p.slug || ""}>{tCatalog("buy now")}</Link>
+                </Button>
               </div>
             </div>
             <AnimatedButton
               href={p.slug || ""}
               animationArea="container"
               className="h-full w-1/2"
-              onMouseEnter={() => setIsHovered(true)}
-              onMouseLeave={() => setIsHovered(false)}
             >
               <Image
                 src={

--- a/src/components/ui/image.tsx
+++ b/src/components/ui/image.tsx
@@ -4,6 +4,8 @@ import { useEffect, useRef } from "react";
 import Image from "next/image";
 import { blurhashToBase64 } from "blurhash-base64";
 
+import { useMediaQuery } from "@/lib/hooks/useMediaQuery";
+
 function ImageContainer({
   aspectRatio,
   children,
@@ -56,12 +58,13 @@ export default function ImageComponent({
   ...props
 }: ImageProps) {
   const videoRef = useRef<HTMLVideoElement>(null);
+  const reduce = useMediaQuery("(prefers-reduced-motion: reduce)");
 
   useEffect(() => {
     if (type !== "video" || !videoRef.current) return;
-    if (playOnHover) videoRef.current.play();
+    if (playOnHover && !reduce) videoRef.current.play();
     else videoRef.current.pause();
-  }, [type, playOnHover]);
+  }, [type, playOnHover, reduce]);
 
   return (
     <ImageContainer aspectRatio={fit !== "cover" ? aspectRatio : undefined}>
@@ -88,7 +91,7 @@ export default function ImageComponent({
           // Use the blurhash as the poster so a frame paints instantly; the
           // video URL itself is not a valid poster image and left it blank.
           poster={blurhash ? blurhashToBase64(blurhash) : undefined}
-          autoPlay={autoPlay}
+          autoPlay={reduce ? false : autoPlay}
           muted={muted}
           loop={loop}
           controls={controls}


### PR DESCRIPTION
Part of a 14-PR parallel polish pass over every customer flow (one PR per flow, all branched off `beta`). Each commit is one independently-reviewed plan item: implement → deep code review + fix → commit.

**Scope (`home`):** accessibility (WCAG: keyboard operability, AA contrast, 44px touch targets, reduced-motion, accessible names), i18n completeness across all 7 locales, and brutalist-brand fidelity (DESIGN.md) — polish that fixes defects without softening the visual language.

**Changes (8):**
- `abfbff2e` feat(home): localize buy-now CTA and make single-featured label operable
- `ad25667f` a11y(home): honor prefers-reduced-motion across the home surface
- `07c05c02` fix(home): use Ink uppercase for preorder badge on product cards
- `154fd65e` a11y(home): blend DOUBLE-hero copy over contain letterbox bars
- `eb58c9bf` a11y(home): give mobile featured CTA a >=44px touch target
- `1eaa1a92` a11y(home): localize and clean up image alt-text fallbacks
- `2d7f4407` fix(home): remove raw 0-based index over archive images
- `1eb5a3a6` fix(home): anchor main-hero copy overlay to the visible viewport

**Verification:** every commit passes `pnpm exec tsc --noEmit` and `pnpm lint` (no new issues on touched files). `pnpm build` compiles, type-checks and lints clean; it stops only at the static-export/prerender step because the backend API is unreachable locally (`ECONNREFUSED`) — a pre-existing condition on `beta`, not introduced here.

**⚠ Sibling-PR conflicts:** these PRs were built in parallel worktrees and edit shared files. Expect merge conflicts when landing more than one, almost all **additive**: `messages/{en,de,fr,it,ja,ko,zh}.json` (touched by 13 of the 14 PRs) and `src/components/ui/toaster.tsx` (5). Merge order matters; later PRs may need a quick rebase on `beta`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
