### PR TITLE
product: a11y, i18n & brand polish (9 items)

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -177,7 +177,10 @@
     "order limit exceeded": "bestelllimit überschritten",
     "select your size to continue": "wählen sie ihre größe, um fortzufahren",
     "one size": "one size",
-    "quantity left": "{count} übrig"
+    "quantity left": "{count} übrig",
+    "image alt": "{name} — bild {index} von {total}",
+    "image alt unnamed": "bild {index} von {total}",
+    "out of stock": "nicht vorrätig"
   },
   "checkout": {
     "contact": "kontakt",
@@ -841,7 +844,11 @@
   "accessibility": {
     "mobile menu": "grbpwr mobiles menü",
     "notify me dialog": "grbpwr benachrichtige mich",
-    "reason label": "grund"
+    "reason label": "grund",
+    "product image viewer": "produktbildansicht",
+    "size selector": "größenauswahl",
+    "previous image": "vorheriges bild",
+    "next image": "nächstes bild"
   },
   "empty-hero": {
     "shop now": "Jetzt einkaufen"

--- a/messages/en.json
+++ b/messages/en.json
@@ -176,7 +176,10 @@
     "order limit exceeded": "order limit exceeded",
     "select your size to continue": "select your size to continue",
     "one size": "one size",
-    "quantity left": "{count} left"
+    "quantity left": "{count} left",
+    "image alt": "{name} — image {index} of {total}",
+    "image alt unnamed": "image {index} of {total}",
+    "out of stock": "out of stock"
   },
   "checkout": {
     "contact": "contact",
@@ -898,7 +901,11 @@
   "accessibility": {
     "mobile menu": "grbpwr mobile menu",
     "notify me dialog": "grbpwr notify me",
-    "reason label": "reason"
+    "reason label": "reason",
+    "product image viewer": "product image viewer",
+    "size selector": "size selector",
+    "previous image": "previous image",
+    "next image": "next image"
   },
   "empty-hero": {
     "shop now": "shop now"

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -177,7 +177,10 @@
     "order limit exceeded": "limite de commande dépassée",
     "select your size to continue": "sélectionnez votre taille pour continuer",
     "one size": "taille unique",
-    "quantity left": "{count} restants"
+    "quantity left": "{count} restants",
+    "image alt": "{name} — image {index} sur {total}",
+    "image alt unnamed": "image {index} sur {total}",
+    "out of stock": "épuisé"
   },
   "checkout": {
     "contact": "contact",
@@ -840,7 +843,11 @@
   "accessibility": {
     "mobile menu": "menu mobile grbpwr",
     "notify me dialog": "dialogue me notifier grbpwr",
-    "reason label": "raison"
+    "reason label": "raison",
+    "product image viewer": "visionneuse d'image produit",
+    "size selector": "sélecteur de taille",
+    "previous image": "image précédente",
+    "next image": "image suivante"
   },
   "empty-hero": {
     "shop now": "Acheter maintenant"

--- a/messages/it.json
+++ b/messages/it.json
@@ -177,7 +177,10 @@
     "order limit exceeded": "limite ordine superato",
     "select your size to continue": "seleziona la tua taglia per continuare",
     "one size": "taglia unica",
-    "quantity left": "{count} rimasti"
+    "quantity left": "{count} rimasti",
+    "image alt": "{name} — immagine {index} di {total}",
+    "image alt unnamed": "immagine {index} di {total}",
+    "out of stock": "esaurito"
   },
   "checkout": {
     "contact": "contatto",
@@ -840,7 +843,11 @@
   "accessibility": {
     "mobile menu": "menu mobile grbpwr",
     "notify me dialog": "dialogo avvisami grbpwr",
-    "reason label": "motivo"
+    "reason label": "motivo",
+    "product image viewer": "visualizzatore immagine prodotto",
+    "size selector": "selettore taglia",
+    "previous image": "immagine precedente",
+    "next image": "immagine successiva"
   },
   "empty-hero": {
     "shop now": "Acquista ora"

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -177,7 +177,10 @@
     "order limit exceeded": "注文限度を超えました",
     "select your size to continue": "続けるにはサイズを選択してください",
     "one size": "ワンサイズ",
-    "quantity left": "残り{count}"
+    "quantity left": "残り{count}",
+    "image alt": "{name} — 画像 {index}／{total}",
+    "image alt unnamed": "画像 {index}／{total}",
+    "out of stock": "在庫切れ"
   },
   "checkout": {
     "contact": "連絡先",
@@ -840,7 +843,11 @@
   "accessibility": {
     "mobile menu": "grbpwrモバイルメニュー",
     "notify me dialog": "grbpwr通知ダイアログ",
-    "reason label": "理由"
+    "reason label": "理由",
+    "product image viewer": "商品画像ビューア",
+    "size selector": "サイズセレクター",
+    "previous image": "前の画像",
+    "next image": "次の画像"
   },
   "empty-hero": {
     "shop now": "今すぐ買う"

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -177,7 +177,10 @@
     "order limit exceeded": "주문 한도 초과",
     "select your size to continue": "계속하려면 사이즈를 선택하세요",
     "one size": "원 사이즈",
-    "quantity left": "{count}개 남음"
+    "quantity left": "{count}개 남음",
+    "image alt": "{name} — 이미지 {index} / {total}",
+    "image alt unnamed": "이미지 {index} / {total}",
+    "out of stock": "품절"
   },
   "checkout": {
     "contact": "연락처",
@@ -840,7 +843,11 @@
   "accessibility": {
     "mobile menu": "grbpwr 모바일 메뉴",
     "notify me dialog": "grbpwr 알림 대화상자",
-    "reason label": "이유"
+    "reason label": "이유",
+    "product image viewer": "제품 이미지 뷰어",
+    "size selector": "사이즈 선택기",
+    "previous image": "이전 이미지",
+    "next image": "다음 이미지"
   },
   "empty-hero": {
     "shop now": "지금 쇼핑하기"

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -177,7 +177,10 @@
     "order limit exceeded": "订单限制已超出",
     "select your size to continue": "请选择尺码以继续",
     "one size": "均码",
-    "quantity left": "剩余{count}件"
+    "quantity left": "剩余{count}件",
+    "image alt": "{name} — 图片 {index}／{total}",
+    "image alt unnamed": "图片 {index}／{total}",
+    "out of stock": "缺货"
   },
   "checkout": {
     "contact": "联系人",
@@ -840,7 +843,11 @@
   "accessibility": {
     "mobile menu": "grbpwr移动菜单",
     "notify me dialog": "grbpwr通知对话框",
-    "reason label": "原因"
+    "reason label": "原因",
+    "product image viewer": "产品图片查看器",
+    "size selector": "尺码选择器",
+    "previous image": "上一张图片",
+    "next image": "下一张图片"
   },
   "empty-hero": {
     "shop now": "立即购买"

--- a/src/app/[locale]/product/[...productParams]/_components/MeasurementPopup.tsx
+++ b/src/app/[locale]/product/[...productParams]/_components/MeasurementPopup.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { common_ProductFull } from "@/api/proto-http/frontend";
+import * as DialogPrimitives from "@radix-ui/react-dialog";
 import { useTranslations } from "next-intl";
 
 import {
@@ -14,7 +15,6 @@ import { useProductBasics } from "@/app/[locale]/product/[...productParams]/_com
 import { useProductPricing } from "@/app/[locale]/product/[...productParams]/_components/utils/useProductPricing";
 
 import { Button } from "../../../../../components/ui/button";
-import { Overlay } from "../../../../../components/ui/overlay";
 import { Text } from "../../../../../components/ui/text";
 import { SubmissionToaster } from "../../../../../components/ui/toaster";
 
@@ -41,6 +41,7 @@ export default function MeasurementPopup({
   const { isSaleApplied, price, priceMinusSale, priceWithSale } =
     useProductPricing({ product });
   const t = useTranslations("product");
+  const tNav = useTranslations("navigation");
 
   const [isModalOpen, setModalOpen] = useState(false);
   const [toastMessage, setToastMessage] = useState<string | undefined>(
@@ -53,23 +54,8 @@ export default function MeasurementPopup({
     selectedSize !== null &&
     outOfStock?.[selectedSize];
 
-  useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        setModalOpen(false);
-      }
-    };
-
-    if (isModalOpen) {
-      window.addEventListener("keydown", handleKeyDown);
-    }
-    return () => {
-      window.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [isModalOpen]);
-
-  const toggleModal = () => {
-    if (!isModalOpen) {
+  const handleOpenChange = (isOpen: boolean) => {
+    if (isOpen) {
       const productId = product.product?.sku || "";
       const pageLocation =
         typeof window !== "undefined" ? window.location.pathname : "";
@@ -85,7 +71,7 @@ export default function MeasurementPopup({
           typeof window !== "undefined" ? window.location.href : "",
       });
     }
-    setModalOpen(!isModalOpen);
+    setModalOpen(isOpen);
   };
 
   async function handleAddToCartComplete() {
@@ -109,27 +95,33 @@ export default function MeasurementPopup({
   }
 
   return (
-    <div>
-      {isModalOpen && (
-        <Overlay
-          cover="screen"
-          disablePointerEvents={false}
-          onClick={toggleModal}
-        />
-      )}
-      <Button variant="underline" className="uppercase" onClick={toggleModal}>
-        {t("size guide")}
-      </Button>
-      {isModalOpen && (
+    <DialogPrimitives.Root open={isModalOpen} onOpenChange={handleOpenChange}>
+      <DialogPrimitives.Trigger asChild>
+        <Button variant="underline" className="uppercase">
+          {t("size guide")}
+        </Button>
+      </DialogPrimitives.Trigger>
+      <DialogPrimitives.Portal>
+        <DialogPrimitives.Overlay className="fixed inset-0 z-10 h-screen bg-overlay" />
         <ModalTransition
           isOpen={isModalOpen}
           contentSlideFrom="right"
           contentClassName="fixed inset-y-2 right-2 z-50 w-[600px] border border-textInactiveColor bg-bgColor p-2.5"
           content={
-            <div className="flex h-full flex-col gap-y-2">
+            <DialogPrimitives.Content className="flex h-full flex-col gap-y-2">
+              <DialogPrimitives.Title className="sr-only">
+                {t("size guide")}
+              </DialogPrimitives.Title>
               <div className="flex items-center justify-between">
                 <Text variant="uppercase">{t("size guide")}</Text>
-                <Button onClick={toggleModal}>[x]</Button>
+                <DialogPrimitives.Close asChild>
+                  <Button
+                    aria-label={tNav("close")}
+                    className="inline-flex min-h-11 min-w-11 items-center justify-center"
+                  >
+                    [x]
+                  </Button>
+                </DialogPrimitives.Close>
               </div>
               <div className="h-full overflow-y-scroll">{children}</div>
               <LoadingButton
@@ -163,15 +155,15 @@ export default function MeasurementPopup({
                     <Text variant="inherit">{price}</Text>
                   ))}
               </LoadingButton>
-            </div>
+            </DialogPrimitives.Content>
           }
         />
-      )}
+      </DialogPrimitives.Portal>
       <SubmissionToaster
         open={maxOrderLimitExceededToastOpen}
         message={toastMessage}
         onOpenChange={setMaxOrderLimitExceededToastOpen}
       />
-    </div>
+    </DialogPrimitives.Root>
   );
 }

--- a/src/app/[locale]/product/[...productParams]/_components/mobile-image-carousel.tsx
+++ b/src/app/[locale]/product/[...productParams]/_components/mobile-image-carousel.tsx
@@ -58,9 +58,16 @@ export function MobileImageCarousel({
   const [isOpen, setIsOpen] = useState(false);
   const [selectedIndex, setSelectedIndex] = useState(0);
   const tAccessibility = useTranslations("accessibility");
+  const tImg = useTranslations("product");
+  const tNav = useTranslations("navigation");
   const [emblaRef, emblaApi] = useEmblaCarousel(EMBLA_OPTIONS, [
     WheelGesturesPlugin(),
   ]);
+
+  const imageAlt = (n: number, total: number) =>
+    productName
+      ? tImg("image alt", { name: productName, index: n, total })
+      : tImg("image alt unnamed", { index: n, total });
 
   useEffect(() => {
     if (!emblaApi) return;
@@ -167,7 +174,7 @@ export function MobileImageCarousel({
                 >
                   <ImageComponent
                     src={compressed?.mediaUrl!}
-                    alt="Product image"
+                    alt={imageAlt(index + 1, media.length)}
                     aspectRatio="4/5"
                     fit="contain"
                     priority={isPriority}
@@ -182,16 +189,17 @@ export function MobileImageCarousel({
       </DialogPrimitives.Trigger>
       <DialogPrimitives.Portal>
         <DialogPrimitives.Overlay className="fixed inset-0 z-50 bg-overlay" />
-        <DialogPrimitives.Content
-          className="fixed inset-0 z-[100] flex flex-col bg-bgColor"
-          onOpenAutoFocus={(e) => e.preventDefault()}
-        >
+        <DialogPrimitives.Content className="fixed inset-0 z-[100] flex flex-col bg-bgColor">
           <DialogPrimitives.Title className="sr-only">
-            {tAccessibility("mobile menu")}
+            {tAccessibility("product image viewer")}
           </DialogPrimitives.Title>
 
           <DialogPrimitives.Close asChild>
-            <Button className="fixed right-4 top-4 z-50" type="button">
+            <Button
+              className="fixed right-4 top-4 z-50 inline-flex min-h-11 min-w-11 items-center justify-center"
+              type="button"
+              aria-label={tNav("close")}
+            >
               [x]
             </Button>
           </DialogPrimitives.Close>
@@ -208,7 +216,7 @@ export function MobileImageCarousel({
             >
               <ImageComponent
                 src={currentMedia.mediaUrl || ""}
-                alt={currentMedia.mediaUrl || "Product thumbnail"}
+                alt={imageAlt(selectedIndex + 1, media.length)}
                 aspectRatio={calculateAspectRatio(
                   currentMedia.width,
                   currentMedia.height,

--- a/src/app/[locale]/product/[...productParams]/_components/mobile-measurements.tsx
+++ b/src/app/[locale]/product/[...productParams]/_components/mobile-measurements.tsx
@@ -37,7 +37,7 @@ export function MobileMeasurements({
   const { isSaleApplied, price, priceMinusSale, priceWithSale } =
     useProductPricing({ product });
   const t = useTranslations("product");
-  const tAccessibility = useTranslations("accessibility");
+  const tNav = useTranslations("navigation");
 
   const isSelectedSizeOutOfStock =
     selectedSize !== undefined &&
@@ -100,13 +100,18 @@ export function MobileMeasurements({
           content={
             <DialogPrimitives.Content className="flex h-full flex-col gap-4">
               <DialogPrimitives.Title className="sr-only">
-                {tAccessibility("mobile menu")}
+                {t("size guide")}
               </DialogPrimitives.Title>
 
               <div className="relative flex shrink-0 items-center justify-between">
                 <Text variant="uppercase">{t("size guide")}</Text>
                 <DialogPrimitives.Close asChild>
-                  <Button>[x]</Button>
+                  <Button
+                    aria-label={tNav("close")}
+                    className="inline-flex min-h-11 min-w-11 items-center justify-center"
+                  >
+                    [x]
+                  </Button>
                 </DialogPrimitives.Close>
               </div>
               <div className="min-h-0 grow overflow-y-auto">

--- a/src/app/[locale]/product/[...productParams]/_components/product-images-carousel.tsx
+++ b/src/app/[locale]/product/[...productParams]/_components/product-images-carousel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useRef } from "react";
+import { useTranslations } from "next-intl";
 import { common_MediaFull } from "@/api/proto-http/frontend";
 
 import {
@@ -22,6 +23,8 @@ export function ProductImagesCarousel({
   productId,
   productName,
 }: Props) {
+  const tA = useTranslations("accessibility");
+  const tImg = useTranslations("product");
   const oneMedia = productMedia.length === 1;
   // The carousel initially shows the slides at/after startIndex (not index 0,
   // which is off-screen). Priority must follow what's actually visible so the
@@ -76,6 +79,8 @@ export function ProductImagesCarousel({
         startIndex={startIndex}
         className="flex h-screen w-full pt-14"
         scrollOnClick={true}
+        prevLabel={tA("previous image")}
+        nextLabel={tA("next image")}
         setSelectedIndex={handleSelectedIndex}
       >
         {mediaForCarousel.map((m, index) => {
@@ -87,7 +92,18 @@ export function ProductImagesCarousel({
             >
               <ImageComponent
                 src={m?.media?.compressed?.mediaUrl!}
-                alt="Product image"
+                alt={
+                  productName
+                    ? tImg("image alt", {
+                        name: productName,
+                        index: (index % productMedia.length) + 1,
+                        total: productMedia.length,
+                      })
+                    : tImg("image alt unnamed", {
+                        index: (index % productMedia.length) + 1,
+                        total: productMedia.length,
+                      })
+                }
                 aspectRatio="4/5"
                 fit="contain"
                 priority={isPriority}

--- a/src/app/[locale]/product/[...productParams]/_components/select-size-add-to-cart/mobile-select-size.tsx
+++ b/src/app/[locale]/product/[...productParams]/_components/select-size-add-to-cart/mobile-select-size.tsx
@@ -35,6 +35,8 @@ export function MobileSelectSize({
     activeSizeId,
   });
   const tAccessibility = useTranslations("accessibility");
+  const t = useTranslations("product");
+  const tNav = useTranslations("navigation");
 
   useEffect(() => {
     if (open) {
@@ -68,14 +70,20 @@ export function MobileSelectSize({
           content={
             <DialogPrimitives.Content className="flex h-full flex-col gap-10">
               <DialogPrimitives.Title className="sr-only">
-                {tAccessibility("mobile menu")}
+                {tAccessibility("size selector")}
               </DialogPrimitives.Title>
-              <DialogPrimitives.Close asChild>
-                <div className="flex items-center justify-between">
-                  <Text variant="uppercase">select size</Text>
-                  <Text variant="uppercase">[x]</Text>
-                </div>
-              </DialogPrimitives.Close>
+              <div className="flex items-center justify-between">
+                <Text variant="uppercase">{t("select size")}</Text>
+                <DialogPrimitives.Close asChild>
+                  <Button
+                    type="button"
+                    aria-label={tNav("close")}
+                    className="min-h-11 min-w-11 inline-flex items-center justify-center"
+                  >
+                    <Text variant="uppercase">[x]</Text>
+                  </Button>
+                </DialogPrimitives.Close>
+              </div>
               <div className="grid grid-cols-4 gap-x-2 gap-y-7">
                 {sizeNames?.map(({ name, id }) => {
                   const isOutOfStock =

--- a/src/app/[locale]/product/[...productParams]/_components/select-size-add-to-cart/mobile-select-size.tsx
+++ b/src/app/[locale]/product/[...productParams]/_components/select-size-add-to-cart/mobile-select-size.tsx
@@ -92,6 +92,11 @@ export function MobileSelectSize({
                   return (
                     <Button
                       type="button"
+                      aria-label={
+                        isOutOfStock
+                          ? `${name} — ${t("out of stock")}`
+                          : undefined
+                      }
                       variant={isOutOfStock ? "strikeThrough" : "default"}
                       className={
                         isOutOfStock

--- a/src/app/[locale]/product/[...productParams]/_components/select-size-add-to-cart/mobile-select-size.tsx
+++ b/src/app/[locale]/product/[...productParams]/_components/select-size-add-to-cart/mobile-select-size.tsx
@@ -78,13 +78,13 @@ export function MobileSelectSize({
                   <Button
                     type="button"
                     aria-label={tNav("close")}
-                    className="min-h-11 min-w-11 inline-flex items-center justify-center"
+                    className="inline-flex min-h-11 min-w-11 items-center justify-center"
                   >
                     <Text variant="uppercase">[x]</Text>
                   </Button>
                 </DialogPrimitives.Close>
               </div>
-              <div className="grid grid-cols-4 gap-x-2 gap-y-7">
+              <div className="grid grid-cols-4 gap-x-2 gap-y-4">
                 {sizeNames?.map(({ name, id }) => {
                   const isOutOfStock =
                     outOfStock?.[id] || sizeQuantity?.[id] === 0;
@@ -94,7 +94,9 @@ export function MobileSelectSize({
                       type="button"
                       variant={isOutOfStock ? "strikeThrough" : "default"}
                       className={
-                        isOutOfStock ? "cursor-pointer uppercase" : "uppercase"
+                        isOutOfStock
+                          ? "inline-flex min-h-11 min-w-11 cursor-pointer items-center justify-center uppercase"
+                          : "inline-flex min-h-11 min-w-11 items-center justify-center uppercase"
                       }
                       key={id}
                       onClick={() => handleSizeClick(id)}

--- a/src/app/[locale]/product/[...productParams]/_components/size-picker.tsx
+++ b/src/app/[locale]/product/[...productParams]/_components/size-picker.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useTranslations } from "next-intl";
+
 import { sendOutOfStockClickEvent } from "@/lib/analitycs/product-engagement";
 import { sendSizeSelectedEvent } from "@/lib/analitycs/sizes";
 import { cn } from "@/lib/utils";
@@ -7,7 +9,6 @@ import { Button } from "@/components/ui/button";
 import { HoverText } from "@/components/ui/hover-text";
 import { Overlay } from "@/components/ui/overlay";
 import { Text } from "@/components/ui/text";
-import { useTranslations } from "next-intl";
 
 type ProductContext = {
   productId: string;
@@ -85,7 +86,7 @@ export function SizePicker({
       <div
         className={cn(
           {
-            "grid grid-cols-4 gap-x-3 gap-y-7": view === "grid",
+            "grid grid-cols-4 gap-x-3 gap-y-4": view === "grid",
             "flex w-full flex-row flex-wrap items-center justify-center gap-5":
               view === "line",
             "flex items-center justify-start": isOneSize,
@@ -110,14 +111,17 @@ export function SizePicker({
               type="button"
               disabled={isDisabled}
               variant={isOutOfStock ? "strikeThrough" : "default"}
-              className={cn("leading-none", {
-                "border-b border-transparent": !isSingleDisplayedSize,
-                "border-textColor":
-                  !isSingleDisplayedSize && isActive && !isOutOfStock,
-                "hover:border-textColor":
-                  !isSingleDisplayedSize && !isActive && !isOutOfStock,
-                "px-3 py-0.5": view === "line" && !isOneSize,
-              })}
+              className={cn(
+                "inline-flex min-h-11 min-w-11 items-center justify-center leading-none",
+                {
+                  "border-b border-transparent": !isSingleDisplayedSize,
+                  "border-textColor":
+                    !isSingleDisplayedSize && isActive && !isOutOfStock,
+                  "hover:border-textColor":
+                    !isSingleDisplayedSize && !isActive && !isOutOfStock,
+                  "px-3 py-0.5": view === "line" && !isOneSize,
+                },
+              )}
               key={id}
               onClick={() => handleSizeSelect(id)}
               onPointerDown={() => handleAnalytics(id, name, isOutOfStock)}

--- a/src/app/[locale]/product/[...productParams]/_components/size-picker.tsx
+++ b/src/app/[locale]/product/[...productParams]/_components/size-picker.tsx
@@ -117,10 +117,6 @@ export function SizePicker({
                 "hover:border-textColor":
                   !isSingleDisplayedSize && !isActive && !isOutOfStock,
                 "px-3 py-0.5": view === "line" && !isOneSize,
-                "!text-textColor":
-                  isOutOfStock && isActive && !isSingleDisplayedSize,
-                "hover:!text-textColor":
-                  isOutOfStock && !isActive && !isSingleDisplayedSize,
               })}
               key={id}
               onClick={() => handleSizeSelect(id)}

--- a/src/app/[locale]/product/[...productParams]/_components/size-picker.tsx
+++ b/src/app/[locale]/product/[...productParams]/_components/size-picker.tsx
@@ -110,6 +110,12 @@ export function SizePicker({
             <Button
               type="button"
               disabled={isDisabled}
+              aria-pressed={isActive}
+              aria-label={
+                isOutOfStock
+                  ? `${displayName} — ${t("out of stock")}`
+                  : undefined
+              }
               variant={isOutOfStock ? "strikeThrough" : "default"}
               className={cn(
                 "inline-flex min-h-11 min-w-11 items-center justify-center leading-none",

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -72,7 +72,8 @@ export const buttonVariants = cva(
       strikeThrough: [
         "relative",
         "text-textBaseSize",
-        "text-textInactiveColor",
+        "text-textColor",
+        "disabled:text-textInactiveColor",
         "before:absolute",
         "before:top-1/2",
         "before:left-0",

--- a/src/components/ui/carousel.tsx
+++ b/src/components/ui/carousel.tsx
@@ -21,6 +21,8 @@ type CarouselProps = {
   dragFree?: boolean;
   skipSnaps?: boolean;
   scrollOnClick?: boolean;
+  prevLabel?: string;
+  nextLabel?: string;
   setSelectedIndex?: (index: number) => void;
 };
 
@@ -37,6 +39,8 @@ export function Carousel({
   dragFree = true,
   skipSnaps = true,
   scrollOnClick = false,
+  prevLabel,
+  nextLabel,
   setSelectedIndex,
 }: CarouselProps) {
   const childrenCount = Children.count(children);
@@ -128,14 +132,23 @@ export function Carousel({
     >
       <div className={className}>{children}</div>
       {scrollOnClick && (
-        <div className="absolute inset-0 flex h-full text-bgColor mix-blend-exclusion">
-          <div
+        <div className="absolute inset-0 flex h-full">
+          <button
+            type="button"
             onClick={scrollPrev}
+            aria-label={prevLabel}
             className="flex h-full flex-1 items-center justify-start"
           >
-            <Text className="pl-8 leading-none">{"<"}</Text>
-          </div>
-          <div onClick={scrollNext} className="h-full flex-1" />
+            <Text className="pl-8 leading-none text-bgColor mix-blend-exclusion">
+              {"<"}
+            </Text>
+          </button>
+          <button
+            type="button"
+            onClick={scrollNext}
+            aria-label={nextLabel}
+            className="h-full flex-1"
+          />
         </div>
       )}
     </div>


### PR DESCRIPTION
Part of a 14-PR parallel polish pass over every customer flow (one PR per flow, all branched off `beta`). Each commit is one independently-reviewed plan item: implement → deep code review + fix → commit.

**Scope (`product`):** accessibility (WCAG: keyboard operability, AA contrast, 44px touch targets, reduced-motion, accessible names), i18n completeness across all 7 locales, and brutalist-brand fidelity (DESIGN.md) — polish that fixes defects without softening the visual language.

**Changes (9):**
- `8c14f0e8` feat(product): add missing PDP i18n keys to every locale
- `47c03677` a11y(product): label mobile size sheet and scope its close control
- `b8c69bcf` a11y(product): correct size-guide sheet title and label close button
- `0dda0a13` a11y(product): fix fullscreen zoom title, alt text, and close button
- `644d180f` a11y(product): keyboard-operable gallery prev/next with visible ring + descriptive alt
- `3be4992b` a11y(product): meet AA on out-of-stock size labels
- `29c7c574` a11y(product): enforce 44px touch targets on size buttons
- `fb4e6639` a11y(product): expose size selection and out-of-stock state to AT
- `8f08e4fb` refactor(product): use Radix dialog semantics for desktop size-guide

**Verification:** every commit passes `pnpm exec tsc --noEmit` and `pnpm lint` (no new issues on touched files). `pnpm build` compiles, type-checks and lints clean; it stops only at the static-export/prerender step because the backend API is unreachable locally (`ECONNREFUSED`) — a pre-existing condition on `beta`, not introduced here.

**⚠ Sibling-PR conflicts:** these PRs were built in parallel worktrees and edit shared files. Expect merge conflicts when landing more than one, almost all **additive**: `messages/{en,de,fr,it,ja,ko,zh}.json` (touched by 13 of the 14 PRs) and `src/components/ui/toaster.tsx` (5). Merge order matters; later PRs may need a quick rebase on `beta`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
