### PR TITLE
services-legal: a11y, i18n & brand polish (8 items)

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -477,7 +477,7 @@
     "sizing": "Größe",
     "characteristics": "Eigenschaften",
     "care": "Pflege",
-    "gender": "Frl., Fr., Ms",
+    "ms": "Frl., Fr., Ms",
     "mx": "Mx",
     "mr": "Hr.",
     "i'd rather not say": "möchte ich nicht angeben",

--- a/messages/de.json
+++ b/messages/de.json
@@ -594,7 +594,8 @@
     "cookie settings": "cookie-einstellungen",
     "frequently asked questions": "häufig gestellte fragen",
     "placing an order": "bestellung aufgeben, sendungsverfolgung, rückgaberichtlinien, kundendienst und nachhaltige entwicklung.",
-    "membership policy": "mitgliedschaftsrichtlinie"
+    "membership policy": "mitgliedschaftsrichtlinie",
+    "content_load_error": "inhalt konnte nicht geladen werden"
   },
   "colors": {
     "black": "schwarz",

--- a/messages/de.json
+++ b/messages/de.json
@@ -641,6 +641,7 @@
     "notify_me_success": "wir benachrichtigen sie, wenn dieser artikel wieder verfügbar ist.",
     "invalid_email": "bitte geben sie eine gültige e-mail-adresse ein",
     "email_copied": "e-mail kopiert",
+    "copy_email": "e-mail kopieren",
     "cart_outdated": "ihr warenkorb ist veraltet",
     "cart_modified": "einige artikel haben sich geändert — ihr warenkorb wurde aktualisiert",
     "cart_unavailable": "die artikel in ihrem warenkorb sind nicht mehr verfügbar",

--- a/messages/en.json
+++ b/messages/en.json
@@ -651,7 +651,8 @@
     "cookie settings": "cookie settings",
     "frequently asked questions": "frequently asked questions",
     "placing an order": "placing an order, order tracking, returns policy, aftersale services and sustainable development.",
-    "membership policy": "membership policy"
+    "membership policy": "membership policy",
+    "content_load_error": "couldn't load content"
   },
   "colors": {
     "black": "black",

--- a/messages/en.json
+++ b/messages/en.json
@@ -698,6 +698,7 @@
     "notify_me_success": "you'll be notified when this item is back in stock.",
     "invalid_email": "please enter a valid email address",
     "email_copied": "e-mail copied",
+    "copy_email": "copy email",
     "cart_outdated": "your cart is outdated",
     "cart_modified": "some items changed — your cart has been updated",
     "cart_unavailable": "items in your cart are no longer available",

--- a/messages/en.json
+++ b/messages/en.json
@@ -534,7 +534,7 @@
     "sizing": "sizing",
     "characteristics": "characteristics",
     "care": "care",
-    "gender": "miss, mrs, ms",
+    "ms": "miss, mrs, ms",
     "mx": "mx",
     "mr": "mr",
     "i'd rather not say": "i'd rather not say",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -593,7 +593,8 @@
     "cookie settings": "paramètres des cookies",
     "frequently asked questions": "questions fréquemment posées",
     "placing an order": "passer une commande, suivi de commande, politique de retour, services après-vente et développement durable.",
-    "membership policy": "politique d'adhésion"
+    "membership policy": "politique d'adhésion",
+    "content_load_error": "impossible de charger le contenu"
   },
   "colors": {
     "black": "noir",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -640,6 +640,7 @@
     "notify_me_success": "nous vous préviendrons lorsque cet article sera de nouveau en stock.",
     "invalid_email": "veuillez saisir une adresse email valide",
     "email_copied": "email copié",
+    "copy_email": "copier l'email",
     "cart_outdated": "votre panier est obsolète",
     "cart_modified": "certains articles ont changé — votre panier a été mis à jour",
     "cart_unavailable": "les articles de votre panier ne sont plus disponibles",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -476,7 +476,7 @@
     "sizing": "taille",
     "characteristics": "caractéristiques",
     "care": "entretien",
-    "gender": "mlle, mme, ms",
+    "ms": "mlle, mme, ms",
     "mx": "mx",
     "mr": "m.",
     "i'd rather not say": "je préfère ne pas le dire",

--- a/messages/it.json
+++ b/messages/it.json
@@ -640,6 +640,7 @@
     "notify_me_success": "ti avviseremo quando questo articolo sarà di nuovo disponibile.",
     "invalid_email": "inserisci un indirizzo email valido",
     "email_copied": "email copiata",
+    "copy_email": "copia email",
     "cart_outdated": "il tuo carrello è obsoleto",
     "cart_modified": "alcuni articoli sono cambiati — il tuo carrello è stato aggiornato",
     "cart_unavailable": "gli articoli nel tuo carrello non sono più disponibili",

--- a/messages/it.json
+++ b/messages/it.json
@@ -593,7 +593,8 @@
     "cookie settings": "impostazioni cookie",
     "frequently asked questions": "domande frequenti",
     "placing an order": "effettuare un ordine, tracciamento dell'ordine, politica dei resi, servizi post-vendita e sviluppo sostenibile.",
-    "membership policy": "politica di membership"
+    "membership policy": "politica di membership",
+    "content_load_error": "impossibile caricare il contenuto"
   },
   "colors": {
     "black": "nero",

--- a/messages/it.json
+++ b/messages/it.json
@@ -476,7 +476,7 @@
     "sizing": "taglie",
     "characteristics": "caratteristiche",
     "care": "cura",
-    "gender": "sig.na, sig.ra, ms",
+    "ms": "sig.na, sig.ra, ms",
     "mx": "mx",
     "mr": "sig.",
     "i'd rather not say": "preferisco non dirlo",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -593,7 +593,8 @@
     "cookie settings": "クッキー設定",
     "frequently asked questions": "よくある質問",
     "placing an order": "注文方法、注文追跡、返品ポリシー、アフターサービス、持続可能な開発について。",
-    "membership policy": "メンバーシップポリシー"
+    "membership policy": "メンバーシップポリシー",
+    "content_load_error": "コンテンツを読み込めませんでした"
   },
   "colors": {
     "black": "黒",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -640,6 +640,7 @@
     "notify_me_success": "この商品が再入荷したらお知らせします。",
     "invalid_email": "有効なメールアドレスを入力してください",
     "email_copied": "メールアドレスがコピーされました",
+    "copy_email": "メールアドレスをコピー",
     "cart_outdated": "カートが古くなっています",
     "cart_modified": "一部の商品が変更されました — カートを更新しました",
     "cart_unavailable": "カート内の商品は現在ご利用いただけません",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -476,7 +476,7 @@
     "sizing": "サイズ",
     "characteristics": "特徴",
     "care": "お手入れ",
-    "gender": "さん, 様, Ms",
+    "ms": "さん, 様, Ms",
     "mx": "Mx",
     "mr": "様",
     "i'd rather not say": "回答しない",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -640,6 +640,7 @@
     "notify_me_success": "이 상품이 재입고되면 알려드리겠습니다.",
     "invalid_email": "유효한 이메일 주소를 입력해주세요",
     "email_copied": "이메일 복사됨",
+    "copy_email": "이메일 복사",
     "cart_outdated": "장바구니가 오래되었습니다",
     "cart_modified": "일부 상품이 변경되어 장바구니가 업데이트되었습니다",
     "cart_unavailable": "장바구니에 담긴 상품은 더 이상 구매할 수 없습니다",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -476,7 +476,7 @@
     "sizing": "사이즈",
     "characteristics": "특징",
     "care": "관리",
-    "gender": "님, 씨, Ms",
+    "ms": "님, 씨, Ms",
     "mx": "Mx",
     "mr": "님",
     "i'd rather not say": "답변하지 않음",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -593,7 +593,8 @@
     "cookie settings": "쿠키 설정",
     "frequently asked questions": "자주 묻는 질문",
     "placing an order": "주문하기, 주문 추적, 반품 정책, 애프터서비스 및 지속가능한 발전.",
-    "membership policy": "멤버십 정책"
+    "membership policy": "멤버십 정책",
+    "content_load_error": "콘텐츠를 불러올 수 없습니다"
   },
   "colors": {
     "black": "검은색",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -593,7 +593,8 @@
     "cookie settings": "cookie设置",
     "frequently asked questions": "常见问题",
     "placing an order": "下订单、订单跟踪、退货政策、售后服务和可持续发展。",
-    "membership policy": "会员政策"
+    "membership policy": "会员政策",
+    "content_load_error": "无法加载内容"
   },
   "colors": {
     "black": "黑色",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -640,6 +640,7 @@
     "notify_me_success": "该商品补货后我们会通知您。",
     "invalid_email": "请输入有效的邮箱地址",
     "email_copied": "邮箱已复制",
+    "copy_email": "复制邮箱",
     "cart_outdated": "您的购物车已过期",
     "cart_modified": "部分商品已变更 — 您的购物车已更新",
     "cart_unavailable": "您购物车中的商品已不再可用",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -476,7 +476,7 @@
     "sizing": "尺码",
     "characteristics": "特性",
     "care": "保养",
-    "gender": "小姐, 女士, Ms",
+    "ms": "小姐, 女士, Ms",
     "mx": "Mx",
     "mr": "先生",
     "i'd rather not say": "不愿透露",

--- a/src/app/[locale]/(checkout)/checkout/_components/new-order-form/fields-group-container.tsx
+++ b/src/app/[locale]/(checkout)/checkout/_components/new-order-form/fields-group-container.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useId, useState } from "react";
 
 import { cn } from "@/lib/utils";
 import { Arrow } from "@/components/ui/icons/arrow";
@@ -29,6 +29,7 @@ interface FieldsGroupContainerProps {
   titleClassName?: string;
   onToggle?: () => void;
   childrenOffset?: "title" | "stage";
+  headingComponent?: "h2" | "h3" | "h4";
 }
 
 export default function FieldsGroupContainer({
@@ -50,8 +51,10 @@ export default function FieldsGroupContainer({
   titleClassName,
   onToggle,
   childrenOffset = "title",
+  headingComponent: HeadingComponent,
 }: FieldsGroupContainerProps) {
   const [localIsOpen, setLocalIsOpen] = useState(isOpen);
+  const bodyId = useId();
 
   useEffect(() => {
     setLocalIsOpen(isOpen);
@@ -63,7 +66,106 @@ export default function FieldsGroupContainer({
     onToggle?.();
   };
 
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (disabled || !collapsible) return;
+    if (e.key === "Enter" || e.key === " ") {
+      if (e.key === " ") e.preventDefault();
+      handleToggle();
+    }
+  };
+
   const gated = disabled && Boolean(disabledHint);
+
+  const headerRow = (
+    <div
+      className={cn(
+        "flex min-w-0 items-center justify-between",
+        { "h-auto cursor-pointer lg:h-20": disabled },
+        { "cursor-pointer": collapsible && !disabled },
+        clickableAreaClassName,
+      )}
+      onClick={collapsible ? handleToggle : undefined}
+      {...(collapsible
+        ? {
+            role: "button" as const,
+            tabIndex: disabled ? -1 : 0,
+            "aria-expanded": localIsOpen,
+            "aria-controls": bodyId,
+            "aria-disabled": disabled || undefined,
+            onKeyDown: handleKeyDown,
+          }
+        : {})}
+    >
+      <div className="flex min-w-0 flex-1 items-center gap-x-6">
+        {stage && (
+          <Text
+            variant="uppercase"
+            className={cn("w-8 text-textColor", {
+              "text-textInactiveColor": disabled,
+            })}
+          >
+            {stage}
+          </Text>
+        )}
+
+        <div
+          className={cn(
+            "flex min-w-0 flex-1",
+            gated
+              ? "flex-col items-start gap-y-1 lg:flex-row lg:items-center lg:justify-between"
+              : "items-center justify-between",
+            { "text-textInactiveColor": disabled },
+            titleWrapperClassName,
+          )}
+        >
+          <div className="flex min-w-0 items-center">
+            {collapsible && signPosition === "before" && (
+              <CollapsibleSign
+                sign={signType}
+                isOpen={localIsOpen}
+                position={signPosition}
+                disabled={disabled}
+                className="shrink-0"
+              />
+            )}
+            <Text
+              variant="uppercase"
+              className={cn(
+                "min-w-0 text-textColor",
+                titleClassName ?? "truncate",
+                {
+                  "text-textInactiveColor": disabled,
+                },
+              )}
+            >
+              {title}
+            </Text>
+          </div>
+          {gated ? (
+            <Text
+              variant="uppercase"
+              component="span"
+              className="shrink-0 text-xs text-textInactiveColor lg:ml-4"
+            >
+              {disabledHint}
+            </Text>
+          ) : (
+            preview && <div className="shrink-0">{preview}</div>
+          )}
+        </div>
+      </div>
+
+      {collapsible && signPosition === "after" && (
+        <CollapsibleSign
+          sign={signType}
+          isOpen={localIsOpen}
+          position={signPosition}
+          disabled={disabled}
+          className="shrink-0"
+        />
+      )}
+    </div>
+  );
 
   return (
     <div
@@ -73,86 +175,14 @@ export default function FieldsGroupContainer({
         className,
       )}
     >
-      <div
-        className={cn(
-          "flex min-w-0 items-center justify-between",
-          { "h-auto cursor-pointer lg:h-20": disabled },
-          { "cursor-pointer": collapsible && !disabled },
-          clickableAreaClassName,
-        )}
-        onClick={collapsible ? handleToggle : undefined}
-      >
-        <div className="flex min-w-0 flex-1 items-center gap-x-6">
-          {stage && (
-            <Text
-              variant="uppercase"
-              className={cn("w-8 text-textColor", {
-                "text-textInactiveColor": disabled,
-              })}
-            >
-              {stage}
-            </Text>
-          )}
-
-          <div
-            className={cn(
-              "flex min-w-0 flex-1",
-              gated
-                ? "flex-col items-start gap-y-1 lg:flex-row lg:items-center lg:justify-between"
-                : "items-center justify-between",
-              { "text-textInactiveColor": disabled },
-              titleWrapperClassName,
-            )}
-          >
-            <div className="flex min-w-0 items-center">
-              {collapsible && signPosition === "before" && (
-                <CollapsibleSign
-                  sign={signType}
-                  isOpen={localIsOpen}
-                  position={signPosition}
-                  disabled={disabled}
-                  className="shrink-0"
-                />
-              )}
-              <Text
-                variant="uppercase"
-                className={cn(
-                  "min-w-0 text-textColor",
-                  titleClassName ?? "truncate",
-                  {
-                    "text-textInactiveColor": disabled,
-                  },
-                )}
-              >
-                {title}
-              </Text>
-            </div>
-            {gated ? (
-              <Text
-                variant="uppercase"
-                component="span"
-                className="shrink-0 text-xs text-textInactiveColor lg:ml-4"
-              >
-                {disabledHint}
-              </Text>
-            ) : (
-              preview && <div className="shrink-0">{preview}</div>
-            )}
-          </div>
-        </div>
-
-        {collapsible && signPosition === "after" && (
-          <CollapsibleSign
-            sign={signType}
-            isOpen={localIsOpen}
-            position={signPosition}
-            disabled={disabled}
-            className="shrink-0"
-          />
-        )}
-      </div>
+      {HeadingComponent ? (
+        <HeadingComponent className="contents">{headerRow}</HeadingComponent>
+      ) : (
+        headerRow
+      )}
 
       <div
+        id={bodyId}
         className={cn(childrenSpacingClass, {
           hidden: collapsible && !localIsOpen,
           "lg:ml-14": !collapsible && !!stage && childrenOffset !== "stage",

--- a/src/app/[locale]/(content)/_components/aftersale-selector.tsx
+++ b/src/app/[locale]/(content)/_components/aftersale-selector.tsx
@@ -62,6 +62,7 @@ export default function AftersaleSelector<T extends FieldValues>({
                   type="button"
                   size="lg"
                   disabled={disabled}
+                  aria-pressed={l === field.value}
                   onClick={() => field.onChange(l)}
                   className={cn(
                     "border border-textColor uppercase",

--- a/src/app/[locale]/(content)/_components/collapsible-sections.tsx
+++ b/src/app/[locale]/(content)/_components/collapsible-sections.tsx
@@ -83,6 +83,7 @@ export function CollapsibleSections({
                       ).padStart(2, "0")
                 }
                 title={heading}
+                headingComponent="h2"
                 isOpen={openSection === index}
                 onToggle={() => toggleSection(index)}
                 clickableAreaClassName="w-full min-h-16 h-auto gap-x-4 py-4 max-lg:items-start lg:h-16 lg:items-center lg:py-0"

--- a/src/app/[locale]/(content)/_components/constant.ts
+++ b/src/app/[locale]/(content)/_components/constant.ts
@@ -71,7 +71,7 @@ export const options = {
 }
 
 export const civility = [
-    "gender",
+    "ms",
     "mx",
     "mr",
     "i'd rather not say",

--- a/src/app/[locale]/(content)/_components/markdown-components.tsx
+++ b/src/app/[locale]/(content)/_components/markdown-components.tsx
@@ -26,11 +26,15 @@ function hasLowercaseLetter(text: string): boolean {
   return /\p{Ll}/u.test(text);
 }
 
+function hasUppercaseLetter(text: string): boolean {
+  return /\p{Lu}/u.test(text);
+}
+
 function isSubsectionTitle(plain: string): boolean {
   if (plain.length === 0 || plain.length > SUBSECTION_TITLE_MAX_LENGTH) {
     return false;
   }
-  return !hasLowercaseLetter(plain);
+  return hasUppercaseLetter(plain) && !hasLowercaseLetter(plain);
 }
 
 const MarkdownParagraph = ({

--- a/src/app/[locale]/(content)/_components/markdown-components.tsx
+++ b/src/app/[locale]/(content)/_components/markdown-components.tsx
@@ -64,7 +64,7 @@ const MarkdownParagraph = ({
   return (
     <div
       className={cn(
-        "content-md-block",
+        "content-md-block leading-normal",
         BLOCK_GAP,
         isTitle && "mt-8 uppercase lg:mt-12",
       )}
@@ -78,7 +78,7 @@ const MarkdownList = ({ children, className, ...props }: any) => (
   <ul
     {...props}
     className={cn(
-      "not-prose list-outside list-disc space-y-0 pl-5 leading-none marker:text-[inherit] [&>li]:my-0 [&_.content-md-block]:mb-0",
+      "not-prose list-outside list-disc space-y-0 pl-5 leading-none marker:text-[inherit] [&>li]:my-0 [&_.content-md-block]:mb-0 [&_.content-md-block]:leading-none",
       BLOCK_GAP,
       className,
     )}
@@ -91,7 +91,7 @@ const MarkdownOrderedList = ({ children, className, ...props }: any) => (
   <ol
     {...props}
     className={cn(
-      "not-prose list-outside list-decimal space-y-3 pl-5 leading-none marker:text-[inherit]",
+      "not-prose list-outside list-decimal space-y-3 pl-5 leading-none marker:text-[inherit] [&_.content-md-block]:leading-none",
       BLOCK_GAP,
       className,
     )}
@@ -104,7 +104,7 @@ const MarkdownListItem = ({ children, className, ...props }: any) => (
   <li
     {...props}
     className={cn(
-      "not-prose leading-none [&>ul]:mt-3 [&_.content-md-block:not(:last-child)]:mb-3 [&_.content-md-block]:mb-0",
+      "not-prose leading-none [&>ul]:mt-3 [&_.content-md-block:not(:last-child)]:mb-3 [&_.content-md-block]:mb-0 [&_.content-md-block]:leading-none",
       className,
     )}
   >

--- a/src/app/[locale]/(content)/_components/markdown-content-state.tsx
+++ b/src/app/[locale]/(content)/_components/markdown-content-state.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+
+import { Button } from "@/components/ui/button";
+import { Text } from "@/components/ui/text";
+
+interface Props {
+  loading: boolean;
+  error: string | null;
+  onRetry: () => void;
+  children: React.ReactNode;
+}
+
+/**
+ * Shared loading/error/retry wrapper for markdown-backed content surfaces
+ * (FAQ, legal notices). Renders a flat hairline skeleton while loading and a
+ * localized, retryable message on error. A legitimately empty 200 response
+ * (error === null) renders children.
+ */
+export function MarkdownContentState({
+  loading,
+  error,
+  onRetry,
+  children,
+}: Props) {
+  const t = useTranslations("content");
+  const tError = useTranslations("error");
+
+  if (loading) {
+    return (
+      <div className="w-full" aria-busy="true">
+        <div className="h-16 border-b border-textColor" />
+        <div className="h-16 border-b border-textColor" />
+        <div className="h-16 border-b border-transparent" />
+      </div>
+    );
+  }
+
+  if (error != null) {
+    return (
+      <div className="flex w-full flex-col items-start gap-y-4">
+        <Text variant="uppercase">{t("content_load_error")}</Text>
+        <Button
+          variant="simpleReverseWithBorder"
+          className="px-4 py-2.5 uppercase"
+          onClick={onRetry}
+        >
+          {tError("retry")}
+        </Button>
+      </div>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/src/app/[locale]/(content)/_components/use-markdown-content.ts
+++ b/src/app/[locale]/(content)/_components/use-markdown-content.ts
@@ -5,6 +5,7 @@ export interface MarkdownContentHook {
     content: string;
     loading: boolean;
     error: string | null;
+    retry: () => void;
 }
 
 /**
@@ -17,6 +18,7 @@ export const useMarkdownContent = (
     const [content, setContent] = useState<string>("");
     const [loading, setLoading] = useState<boolean>(true);
     const [error, setError] = useState<string | null>(null);
+    const [reloadKey, setReloadKey] = useState<number>(0);
 
     useEffect(() => {
         const loadContent = async () => {
@@ -53,7 +55,7 @@ export const useMarkdownContent = (
             }
 
             setError(lastError || "Unable to load content from provided paths");
-            setContent("Error loading content. Please try again later.");
+            setContent("");
             setLoading(false);
         };
 
@@ -62,7 +64,13 @@ export const useMarkdownContent = (
         Array.isArray(filePathOrPaths)
             ? filePathOrPaths.join("\0")
             : filePathOrPaths,
+        reloadKey,
     ]);
 
-    return { content, loading, error };
+    return {
+        content,
+        loading,
+        error,
+        retry: () => setReloadKey((k) => k + 1),
+    };
 };

--- a/src/app/[locale]/(content)/aftersale-services/_components/index.tsx
+++ b/src/app/[locale]/(content)/aftersale-services/_components/index.tsx
@@ -188,7 +188,7 @@ function PersonalInfoForm() {
         placeholder={t("enter notes")}
         showCharCount
         maxLength={1500}
-        className="placeholder:uppercase placeholder:text-textInactiveColor"
+        className="placeholder:uppercase placeholder:text-textColor"
       />
     </div>
   );

--- a/src/app/[locale]/(content)/aftersale-services/_components/index.tsx
+++ b/src/app/[locale]/(content)/aftersale-services/_components/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { keyboardRestrictions } from "@/constants";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -51,6 +51,18 @@ export default function AftersaleForm() {
   const subjectList = selectedTopic
     ? options[selectedTopic as keyof typeof options]
     : [];
+
+  // Clear the subject whenever the topic changes so a stale subject from the
+  // previous topic cannot satisfy min(1) and submit a contradictory pair.
+  // Skip the initial mount to preserve the preset defaultValues.
+  const isInitialTopicMount = useRef(true);
+  useEffect(() => {
+    if (isInitialTopicMount.current) {
+      isInitialTopicMount.current = false;
+      return;
+    }
+    form.resetField("subject");
+  }, [form, selectedTopic]);
 
   const formSteps = [
     {

--- a/src/app/[locale]/(content)/aftersale-services/page.tsx
+++ b/src/app/[locale]/(content)/aftersale-services/page.tsx
@@ -20,9 +20,13 @@ export default async function AftersaleServicesPage({
     <FlexibleLayout theme={isWebsiteEnabled ? "light" : "dark"}>
       <div
         id="aftersale-services-page"
-        className="min-dvh flex h-full w-full flex-col items-center justify-center gap-12 px-2.5 py-24 text-textColor lg:gap-16 lg:px-96"
+        className="flex h-full w-full flex-col items-center justify-center gap-12 px-2.5 py-24 text-textColor lg:gap-16 lg:px-96"
       >
-        <Text variant="uppercase" className="w-full text-center lg:text-left">
+        <Text
+          component="h1"
+          variant="uppercase"
+          className="w-full text-center lg:text-left"
+        >
           {t("aftersale services")}
         </Text>
         <div className="w-full">

--- a/src/app/[locale]/(content)/client-services/page.tsx
+++ b/src/app/[locale]/(content)/client-services/page.tsx
@@ -20,11 +20,13 @@ export default async function ClientServices({
     <FlexibleLayout>
       <div className="h-full space-y-12 px-2.5 pt-8 lg:space-y-32 lg:px-28 lg:pt-32">
         <div className="space-y-8">
-          <Text variant="uppercase">{t("title")}</Text>
-          <Text>
-            {t("welcome")}
-            <br /> {t("description")}
+          <Text component="h1" variant="uppercase">
+            {t("title")}
           </Text>
+          <div className="space-y-3 lg:max-w-2xl">
+            <Text>{t("welcome")}</Text>
+            <Text>{t("description")}</Text>
+          </div>
         </div>
         <div className="space-y-20">
           <div className="flex flex-col justify-between gap-y-12 lg:flex-row">

--- a/src/app/[locale]/(content)/faq/page.tsx
+++ b/src/app/[locale]/(content)/faq/page.tsx
@@ -7,13 +7,14 @@ import FlexibleLayout from "@/components/flexible-layout";
 import { Text } from "@/components/ui/text";
 
 import { CollapsibleSections } from "../_components/collapsible-sections";
+import { MarkdownContentState } from "../_components/markdown-content-state";
 import { useMarkdownContent } from "../_components/use-markdown-content";
 
 export default function FaqPage() {
   const locale = useLocale();
   const t = useTranslations("content");
   const { dictionary } = useDataContext();
-  const { content } = useMarkdownContent([
+  const { content, loading, error, retry } = useMarkdownContent([
     `/content/faq/faq.${locale}.md`,
     "/content/faq/faq.md",
   ]);
@@ -29,7 +30,9 @@ export default function FaqPage() {
             </Text>
             <Text>{t("placing an order")}</Text>
           </div>
-          <CollapsibleSections content={content} />
+          <MarkdownContentState loading={loading} error={error} onRetry={retry}>
+            <CollapsibleSections content={content} />
+          </MarkdownContentState>
         </div>
       </div>
     </FlexibleLayout>

--- a/src/app/[locale]/(content)/faq/page.tsx
+++ b/src/app/[locale]/(content)/faq/page.tsx
@@ -24,7 +24,9 @@ export default function FaqPage() {
       <div className="flex h-full justify-center space-y-12 px-2.5 pt-24 text-textColor lg:space-y-16 lg:px-28">
         <div className="flex flex-col justify-start gap-y-10 lg:w-1/2 lg:gap-y-6">
           <div className="space-y-8">
-            <Text variant="uppercase">{t("frequently asked questions")}</Text>
+            <Text component="h1" variant="uppercase">
+              {t("frequently asked questions")}
+            </Text>
             <Text>{t("placing an order")}</Text>
           </div>
           <CollapsibleSections content={content} />

--- a/src/app/[locale]/(content)/legal-notices/legal-notices.tsx
+++ b/src/app/[locale]/(content)/legal-notices/legal-notices.tsx
@@ -8,6 +8,7 @@ import { Text } from "@/components/ui/text";
 import { CollapsibleSections } from "../_components/collapsible-sections";
 import { LegalSection, legalSections } from "../_components/constant";
 import { CookieContent } from "../_components/cookie-content";
+import { MarkdownContentState } from "../_components/markdown-content-state";
 import { useMarkdownContent } from "../_components/use-markdown-content";
 
 export function LegalNotices() {
@@ -39,7 +40,8 @@ export function LegalNotices() {
       ]
     : "";
 
-  const { content } = useMarkdownContent(localizedCandidates);
+  const { content, loading, error, retry } =
+    useMarkdownContent(localizedCandidates);
   return (
     <div className="flex w-full flex-col space-y-10 lg:flex-row lg:space-y-0">
       <div className="flex w-full flex-col lg:w-1/2 lg:gap-y-0">
@@ -66,18 +68,21 @@ export function LegalNotices() {
         {selectedSection === "cookies" ? (
           <CookieContent autoSave={true} />
         ) : (
-          <CollapsibleSections
-            key={selectedSection}
-            content={content}
-            skipFirstSectionNumber={
-              selectedSection === "terms" || selectedSection === "terms-of-sale"
-            }
-            showDirectly={selectedSection === "legal-notice"}
-            autoOpenFirst={autoOpenFirst}
-            onSectionChange={(section) =>
-              setSelectedSection(section as LegalSection)
-            }
-          />
+          <MarkdownContentState loading={loading} error={error} onRetry={retry}>
+            <CollapsibleSections
+              key={selectedSection}
+              content={content}
+              skipFirstSectionNumber={
+                selectedSection === "terms" ||
+                selectedSection === "terms-of-sale"
+              }
+              showDirectly={selectedSection === "legal-notice"}
+              autoOpenFirst={autoOpenFirst}
+              onSectionChange={(section) =>
+                setSelectedSection(section as LegalSection)
+              }
+            />
+          </MarkdownContentState>
         )}
       </div>
     </div>

--- a/src/app/[locale]/(content)/legal-notices/legal-notices.tsx
+++ b/src/app/[locale]/(content)/legal-notices/legal-notices.tsx
@@ -44,7 +44,9 @@ export function LegalNotices() {
     <div className="flex w-full flex-col space-y-10 lg:flex-row lg:space-y-0">
       <div className="flex w-full flex-col lg:w-1/2 lg:gap-y-0">
         <div className="space-y-10">
-          <Text className="uppercase">{t("legal notices")}</Text>
+          <Text component="h1" className="uppercase">
+            {t("legal notices")}
+          </Text>
           <div className="space-y-4">
             {Object.entries(legalSections).map(([key, section]) => (
               <Button

--- a/src/app/[locale]/(content)/legal-notices/legal-notices.tsx
+++ b/src/app/[locale]/(content)/legal-notices/legal-notices.tsx
@@ -53,7 +53,8 @@ export function LegalNotices() {
                 key={key}
                 variant={selectedSection === key ? "underline" : "default"}
                 onClick={() => setSelectedSection(key as LegalSection)}
-                className="uppercase text-textColor"
+                aria-current={selectedSection === key ? "page" : undefined}
+                className="flex min-h-11 items-center uppercase text-textColor hover:underline"
               >
                 {t(section.title)}
               </Button>

--- a/src/app/[locale]/(content)/order-status/page.tsx
+++ b/src/app/[locale]/(content)/order-status/page.tsx
@@ -21,10 +21,14 @@ export default async function OrderStatus({
     <FlexibleLayout theme={isWebsiteEnabled ? "light" : "dark"}>
       <div
         id="order-status-page"
-        className="min-dvh relative flex h-screen w-full flex-col items-center justify-center space-y-12 px-2.5 text-textColor lg:space-y-16 lg:px-96"
+        className="relative flex h-screen w-full flex-col items-center justify-center space-y-12 px-2.5 text-textColor lg:space-y-16 lg:px-96"
       >
         <div className="space-y-9">
-          <Text variant="uppercase" className="text-center lg:text-left">
+          <Text
+            component="h1"
+            variant="uppercase"
+            className="text-center lg:text-left"
+          >
             {t("order status")}
           </Text>
           <Text className="text-justify lg:text-left">{t("text")}</Text>

--- a/src/app/[locale]/(content)/return/page.tsx
+++ b/src/app/[locale]/(content)/return/page.tsx
@@ -20,10 +20,14 @@ export default async function Refund({
     <FlexibleLayout theme={isWebsiteEnabled ? "light" : "dark"}>
       <div
         id="refund-page"
-        className="min-dvh flex h-full w-full flex-col items-center justify-center gap-12 px-2.5 py-24 text-textColor lg:gap-16 lg:px-96"
+        className="flex h-full w-full flex-col items-center justify-center gap-12 px-2.5 py-24 text-textColor lg:gap-16 lg:px-96"
       >
         <div className="space-y-9">
-          <Text variant="uppercase" className="text-center lg:text-left">
+          <Text
+            component="h1"
+            variant="uppercase"
+            className="text-center lg:text-left"
+          >
             {t("return order")}
           </Text>
           <Text className="text-justify lg:text-left">{t("text")}</Text>

--- a/src/components/ui/copy-text.tsx
+++ b/src/components/ui/copy-text.tsx
@@ -55,7 +55,7 @@ export default function CopyText({
     <Text
       size="small"
       variant={variant}
-      onClick={handleCopy}
+      onClick={mode === "toaster" ? undefined : handleCopy}
       className={cn("text cursor-pointer", {
         "text-visitedLinkColor": mode === "toaster" && isCopied,
       })}
@@ -67,7 +67,9 @@ export default function CopyText({
   return (
     <div className={cn("flex h-4 items-center gap-1", className)}>
       {mode === "toaster" ? (
-        <EmailToaster title="email">{textElement}</EmailToaster>
+        <EmailToaster title="email" email={text} onCopy={handleCopy}>
+          {textElement}
+        </EmailToaster>
       ) : (
         <>
           {textElement}

--- a/src/components/ui/form/fields/textarea-field.tsx
+++ b/src/components/ui/form/fields/textarea-field.tsx
@@ -59,7 +59,7 @@ export default function TextareaField({
                 onChange={field.onChange}
               />
               {showCharCount && (
-                <div className="absolute bottom-2 right-2 text-xs text-textInactiveColor">
+                <div className="absolute bottom-2 right-2 text-xs text-textColor">
                   {value.length}
                   {maxLength && `/${maxLength}`}
                 </div>

--- a/src/components/ui/toaster.tsx
+++ b/src/components/ui/toaster.tsx
@@ -22,10 +22,14 @@ export function EmailToaster({
   children,
   className,
   title,
+  email,
+  onCopy,
 }: {
   children: React.ReactNode;
   className?: string;
   title: "email";
+  email: string;
+  onCopy?: () => void;
 }) {
   const [open, setOpen] = useState(false);
   const isEmail = title === "email";
@@ -33,8 +37,12 @@ export function EmailToaster({
   return (
     <>
       <Button
-        className={cn("outline-none", className)}
-        onClick={() => setOpen(true)}
+        className={className}
+        aria-label={`${tToaster("copy_email")} ${email}`}
+        onClick={() => {
+          onCopy?.();
+          setOpen(true);
+        }}
       >
         {children}
       </Button>

--- a/src/components/ui/toggle-switch.tsx
+++ b/src/components/ui/toggle-switch.tsx
@@ -1,3 +1,4 @@
+import { useId } from "react";
 import { Label } from "@radix-ui/react-label";
 import * as Switch from "@radix-ui/react-switch";
 
@@ -14,10 +15,11 @@ export function ToggleSwitch({
   disabled?: boolean;
   onCheckedChange?: (checked: boolean) => void;
 }) {
+  const id = useId();
   return (
     <div className="flex items-start gap-5">
       <Switch.Root
-        id="toggle"
+        id={id}
         checked={checked}
         disabled={disabled}
         onCheckedChange={onCheckedChange}
@@ -26,7 +28,7 @@ export function ToggleSwitch({
         <Switch.Thumb className="block h-2 w-2 translate-x-0.5 bg-bgColor data-[state=checked]:translate-x-3 data-[state=checked]:bg-textColor" />
       </Switch.Root>
       {label && (
-        <Label htmlFor="toggle" className="min-w-0 flex-1">
+        <Label htmlFor={id} className="min-w-0 flex-1">
           <Text variant="uppercase" className="break-words">
             {label}
           </Text>


### PR DESCRIPTION
Part of a 14-PR parallel polish pass over every customer flow (one PR per flow, all branched off `beta`). Each commit is one independently-reviewed plan item: implement → deep code review + fix → commit.

**Scope (`services-legal`):** accessibility (WCAG: keyboard operability, AA contrast, 44px touch targets, reduced-motion, accessible names), i18n completeness across all 7 locales, and brutalist-brand fidelity (DESIGN.md) — polish that fixes defects without softening the visual language.

**Changes (8):**
- `cc7b1b5f` a11y(services-legal): single h1 per page, drop dead min-dvh, split client-services intro
- `bc0f8570` a11y(services-legal): give each cookie toggle a unique id
- `9e4ea70c` fix(services-legal): stop promoting caseless CJK body text to subsection titles
- `59a4aad9` fix(services-legal): restore body line-height; Ink placeholder and char counter
- `8a24bd67` a11y(services-legal): expose selected/pressed state, restore focus ring, fix copy-email, enlarge legal nav targets
- `9328e7e2` fix(services-legal): reset subject on topic change; rename gender civility key
- `6adc456d` a11y(services-legal): make accordion headers keyboard/SR operable with heading semantics
- `c7f5b339` feat(services-legal): add markdown loading skeleton, localized error, and retry

**Verification:** every commit passes `pnpm exec tsc --noEmit` and `pnpm lint` (no new issues on touched files). `pnpm build` compiles, type-checks and lints clean; it stops only at the static-export/prerender step because the backend API is unreachable locally (`ECONNREFUSED`) — a pre-existing condition on `beta`, not introduced here.

**⚠ Sibling-PR conflicts:** these PRs were built in parallel worktrees and edit shared files. Expect merge conflicts when landing more than one, almost all **additive**: `messages/{en,de,fr,it,ja,ko,zh}.json` (touched by 13 of the 14 PRs) and `src/components/ui/toaster.tsx` (5). Merge order matters; later PRs may need a quick rebase on `beta`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
