### PR TITLE
feat(hero): honest /preview/hero editor iframe (postMessage bridge)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -55,44 +55,62 @@ const nextConfig: NextConfig = {
     // catalog/product/home pages. The allowlist still blocks loading scripts
     // from any non-listed origin (the Magecart/skimmer threat). Removing
     // 'unsafe-inline' via nonce + strict-dynamic is a deliberate later step.
-    const csp = [
-      `default-src 'self'`,
-      `script-src 'self' 'unsafe-inline'${isDev ? " 'unsafe-eval'" : ""} https://www.googletagmanager.com https://www.google-analytics.com https://js.stripe.com https://maps.googleapis.com`,
-      `style-src 'self' 'unsafe-inline'`,
-      `img-src 'self' data: blob: https://files.grbpwr.com https://art.grbpwr.com https://cdn.builder.io https://www.googletagmanager.com https://www.google-analytics.com https://www.google.com https://maps.googleapis.com https://maps.gstatic.com https://*.googleusercontent.com https://*.stripe.com`,
-      `font-src 'self' data:`,
+    //
+    // frame-ancestors is parameterised: every path is 'self' only (anti-
+    // clickjacking, especially checkout/account), except /preview/* which also
+    // allows the admin origins so the hero editor can embed the preview iframe.
+    const buildCsp = (frameAncestors: string) =>
       [
-        `connect-src 'self'`,
-        backendOrigin,
-        "https://www.google-analytics.com",
-        "https://*.google-analytics.com",
-        "https://*.analytics.google.com",
-        "https://www.googletagmanager.com",
-        "https://api.stripe.com",
-        // Stripe.js fraud signals (m.stripe.network) + metrics (r.stripe.com) —
-        // documented Stripe origins, reliably hit by Payment Element / 3DS.
-        "https://m.stripe.network",
-        "https://r.stripe.com",
-        "https://maps.googleapis.com",
-        // Dev only: Turbopack HMR websocket + localhost backend.
-        ...(isDev ? ["ws://localhost:*", "http://localhost:*"] : []),
-      ]
-        .filter(Boolean)
-        .join(" "),
-      `frame-src 'self' https://js.stripe.com https://hooks.stripe.com https://m.stripe.network https://art.grbpwr.com`,
-      `worker-src 'self' blob:`,
-      `object-src 'none'`,
-      `base-uri 'self'`,
-      `form-action 'self'`,
-      `frame-ancestors 'self'`,
-      `report-uri /api/csp-report`,
-      `report-to csp-endpoint`,
-    ].join("; ");
+        `default-src 'self'`,
+        `script-src 'self' 'unsafe-inline'${isDev ? " 'unsafe-eval'" : ""} https://www.googletagmanager.com https://www.google-analytics.com https://js.stripe.com https://maps.googleapis.com`,
+        `style-src 'self' 'unsafe-inline'`,
+        `img-src 'self' data: blob: https://files.grbpwr.com https://art.grbpwr.com https://cdn.builder.io https://www.googletagmanager.com https://www.google-analytics.com https://www.google.com https://maps.googleapis.com https://maps.gstatic.com https://*.googleusercontent.com https://*.stripe.com`,
+        `font-src 'self' data:`,
+        [
+          `connect-src 'self'`,
+          backendOrigin,
+          "https://www.google-analytics.com",
+          "https://*.google-analytics.com",
+          "https://*.analytics.google.com",
+          "https://www.googletagmanager.com",
+          "https://api.stripe.com",
+          // Stripe.js fraud signals (m.stripe.network) + metrics (r.stripe.com) —
+          // documented Stripe origins, reliably hit by Payment Element / 3DS.
+          "https://m.stripe.network",
+          "https://r.stripe.com",
+          "https://maps.googleapis.com",
+          // Dev only: Turbopack HMR websocket + localhost backend.
+          ...(isDev ? ["ws://localhost:*", "http://localhost:*"] : []),
+        ]
+          .filter(Boolean)
+          .join(" "),
+        `frame-src 'self' https://js.stripe.com https://hooks.stripe.com https://m.stripe.network https://art.grbpwr.com`,
+        `worker-src 'self' blob:`,
+        `object-src 'none'`,
+        `base-uri 'self'`,
+        `form-action 'self'`,
+        `frame-ancestors ${frameAncestors}`,
+        `report-uri /api/csp-report`,
+        `report-to csp-endpoint`,
+      ].join("; ");
 
-    const securityHeaders = [
+    // Origins allowed to frame the hero-editor preview (/preview/*). Must match
+    // the ADMIN_ORIGINS allowlist in hero-preview-client.tsx. localhost is dev
+    // only — prod/beta storefront never needs a local framer.
+    const previewFrameAncestors = [
+      "https://admin.grbpwr.com",
+      "https://admin.beta.grbpwr.com",
+      ...(isDev ? ["http://localhost:4040"] : []),
+    ].join(" ");
+
+    const csp = buildCsp("'self'");
+    const previewCsp = buildCsp(`'self' ${previewFrameAncestors}`);
+
+    // Security headers shared by every path. Framing headers (CSP + XFO) are
+    // added per-scope below because /preview/* needs different framing rules.
+    const baseSecurityHeaders = [
       { key: "X-Content-Type-Options", value: "nosniff" },
       { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
-      { key: "X-Frame-Options", value: "SAMEORIGIN" },
       // Lock down powerful features the storefront doesn't use. Unlisted
       // features (e.g. payment for Stripe) keep their default allowlist.
       {
@@ -106,14 +124,43 @@ const nextConfig: NextConfig = {
       },
       // Reporting target for the CSP above (modern Reporting API).
       { key: "Reporting-Endpoints", value: 'csp-endpoint="/api/csp-report"' },
+    ];
+
+    // Default: same-origin framing only. X-Frame-Options backs up frame-ancestors
+    // for legacy browsers that don't honour CSP.
+    const securityHeaders = [
+      ...baseSecurityHeaders,
+      { key: "X-Frame-Options", value: "SAMEORIGIN" },
       { key: "Content-Security-Policy", value: csp },
+    ];
+
+    // Preview: drop X-Frame-Options entirely — it has no cross-origin allow value
+    // (ALLOW-FROM is dead), so a lingering SAMEORIGIN would veto the admin embed.
+    // frame-ancestors (admin origins) is the modern, per-origin replacement.
+    const previewSecurityHeaders = [
+      ...baseSecurityHeaders,
+      { key: "Content-Security-Policy", value: previewCsp },
     ];
     const headers: {
       source: string;
       headers: { key: string; value: string }[];
     }[] = [
+      // Preview framing rules first. These paths are EXCLUDED from the global
+      // block below (negative lookahead) so exactly one CSP header is emitted —
+      // duplicate CSP headers would intersect frame-ancestors back to 'self' and
+      // re-block the embed. The three sources cover the raw, locale-prefixed and
+      // country+locale forms the i18n middleware can produce for /preview/*.
+      { source: "/preview/:path*", headers: previewSecurityHeaders },
+      { source: "/:locale/preview/:path*", headers: previewSecurityHeaders },
       {
-        source: "/:path*",
+        source: "/:country/:locale/preview/:path*",
+        headers: previewSecurityHeaders,
+      },
+      {
+        // Every non-preview path. The lookahead excludes a `preview` segment in
+        // position 0–2 (handled above); product slugs merely containing the
+        // substring "preview" still match and keep the strict headers.
+        source: "/((?!(?:[^/]+/){0,2}preview/).*)",
         headers: securityHeaders,
       },
       {

--- a/src/app/[locale]/_components/ads.tsx
+++ b/src/app/[locale]/_components/ads.tsx
@@ -42,7 +42,11 @@ export function Ads({
               (t) => t.languageId === languageId,
             );
             return (
-              <div className="relative h-screen w-full" key={i}>
+              <div
+                className="relative h-screen w-full"
+                key={i}
+                data-hero-block-index={i}
+              >
                 <AnimatedButton
                   href={internalHref(e.single?.exploreLink)}
                   className="group relative h-full w-full text-bgColor"
@@ -139,6 +143,7 @@ export function Ads({
             return (
               <div
                 key={i}
+                data-hero-block-index={i}
                 className="relative flex h-full w-full flex-col lg:flex-row"
               >
                 <AnimatedButton
@@ -231,17 +236,22 @@ export function Ads({
               (t) => t.languageId === languageId,
             );
             return (
-              <FeaturedItems
+              <div
                 key={i}
-                products={e.featuredProducts?.products}
-                headline={productsTranslation?.headline}
-                exploreText={productsTranslation?.exploreText}
-                exploreLink={e.featuredProducts?.exploreLink}
-                itemsQuantity={itemsQuantity}
-                onHeroClick={() =>
-                  sendHeroEvent({ heroType: "HERO_TYPE_FEATURED_PRODUCTS" })
-                }
-              />
+                style={{ display: "contents" }}
+                data-hero-block-index={i}
+              >
+                <FeaturedItems
+                  products={e.featuredProducts?.products}
+                  headline={productsTranslation?.headline}
+                  exploreText={productsTranslation?.exploreText}
+                  exploreLink={e.featuredProducts?.exploreLink}
+                  itemsQuantity={itemsQuantity}
+                  onHeroClick={() =>
+                    sendHeroEvent({ heroType: "HERO_TYPE_FEATURED_PRODUCTS" })
+                  }
+                />
+              </div>
             );
           case "HERO_TYPE_FEATURED_PRODUCTS_TAG":
             const productsTagCount =
@@ -251,28 +261,40 @@ export function Ads({
                 (t) => t.languageId === languageId,
               );
             return (
-              <FeaturedItems
+              <div
                 key={i}
-                products={e.featuredProductsTag?.products?.products}
-                headline={productsTagTranslation?.headline}
-                exploreText={productsTagTranslation?.exploreText}
-                exploreLink={e.featuredProductsTag?.products?.exploreLink}
-                itemsQuantity={productsTagCount}
-                onHeroClick={() =>
-                  sendHeroEvent({ heroType: "HERO_TYPE_FEATURED_PRODUCTS_TAG" })
-                }
-              />
+                style={{ display: "contents" }}
+                data-hero-block-index={i}
+              >
+                <FeaturedItems
+                  products={e.featuredProductsTag?.products?.products}
+                  headline={productsTagTranslation?.headline}
+                  exploreText={productsTagTranslation?.exploreText}
+                  exploreLink={e.featuredProductsTag?.products?.exploreLink}
+                  itemsQuantity={productsTagCount}
+                  onHeroClick={() =>
+                    sendHeroEvent({
+                      heroType: "HERO_TYPE_FEATURED_PRODUCTS_TAG",
+                    })
+                  }
+                />
+              </div>
             );
           case "HERO_TYPE_FEATURED_ARCHIVE":
             return (
-              <HeroArchive
-                entity={e}
+              <div
                 key={i}
-                className="space-y-12 pt-16 lg:py-32"
-                onHeroClick={() =>
-                  sendHeroEvent({ heroType: "HERO_TYPE_FEATURED_ARCHIVE" })
-                }
-              />
+                style={{ display: "contents" }}
+                data-hero-block-index={i}
+              >
+                <HeroArchive
+                  entity={e}
+                  className="space-y-12 pt-16 lg:py-32"
+                  onHeroClick={() =>
+                    sendHeroEvent({ heroType: "HERO_TYPE_FEATURED_ARCHIVE" })
+                  }
+                />
+              </div>
             );
           default:
             return null;

--- a/src/app/[locale]/_components/hero-view.tsx
+++ b/src/app/[locale]/_components/hero-view.tsx
@@ -1,0 +1,25 @@
+import type { common_HeroFullWithTranslations } from "@/api/proto-http/frontend";
+
+import { Ads } from "./ads";
+import { MainAds } from "./main-ads";
+
+// Pure render of the hero blocks (main + ads) from an already-hydrated hero.
+// Deliberately fetch-free: the caller supplies `hero`, so the exact same markup
+// is shared by the homepage (server fetch) and the /preview/hero editor iframe
+// (draft over postMessage) with no duplicated layout.
+//
+// Every block carries `data-hero-block-index` (its position in `hero.entities`);
+// the homepage ignores it, but the /preview/hero iframe reads it on click to tell
+// the editor which block was tapped. index 0 is the main block (`Ads` renders it
+// as null via its default case, so there's no duplicate marker for it).
+export function HeroView({ hero }: { hero?: common_HeroFullWithTranslations }) {
+  return (
+    <>
+      {/* display:contents wrapper = layout-neutral click target for the main block */}
+      <div style={{ display: "contents" }} data-hero-block-index={0}>
+        <MainAds main={hero?.entities?.[0]?.main} />
+      </div>
+      <Ads entities={hero?.entities || []} />
+    </>
+  );
+}

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -8,8 +8,7 @@ import FlexibleLayout from "@/components/flexible-layout";
 import { Disabled } from "@/components/ui/disabled";
 import { EmptyHero } from "@/components/ui/empty-hero";
 
-import { Ads } from "./_components/ads";
-import { MainAds } from "./_components/main-ads";
+import { HeroView } from "./_components/hero-view";
 
 export async function generateMetadata({
   params,
@@ -73,8 +72,7 @@ export default async function Page() {
         dangerouslySetInnerHTML={{ __html: jsonLdHtml(jsonLd) }}
       />
       {/* <PageBackground imageUrl={heroImageUrl} /> */}
-      <MainAds main={hero?.entities?.[0]?.main} />
-      <Ads entities={hero?.entities || []} />
+      <HeroView hero={hero} />
     </FlexibleLayout>
   );
 }

--- a/src/app/[locale]/preview/hero/hero-preview-boundary.tsx
+++ b/src/app/[locale]/preview/hero/hero-preview-boundary.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { Component, type ReactNode } from "react";
+
+interface Props {
+  // A new draft (identity change) clears a previous render failure, so a good
+  // draft recovers instead of staying stuck on the fallback forever.
+  resetKey: unknown;
+  fallback: ReactNode;
+  children: ReactNode;
+}
+
+interface State {
+  failed: boolean;
+  key: unknown;
+}
+
+// A malformed hero draft (missing media, unexpected shape) can throw inside the
+// hero blocks. Without a boundary that throw blanks the whole preview iframe and
+// the editor loses its canvas. Catching it shows a placeholder and recovers on
+// the next draft.
+export class HeroPreviewBoundary extends Component<Props, State> {
+  state: State = { failed: false, key: this.props.resetKey };
+
+  static getDerivedStateFromError(): Partial<State> {
+    return { failed: true };
+  }
+
+  static getDerivedStateFromProps(
+    props: Props,
+    state: State,
+  ): Partial<State> | null {
+    if (props.resetKey !== state.key) {
+      return { failed: false, key: props.resetKey };
+    }
+    return null;
+  }
+
+  componentDidCatch() {
+    // Swallowed on purpose: the fallback keeps the iframe alive and the editor
+    // will push a corrected draft.
+  }
+
+  render() {
+    return this.state.failed ? this.props.fallback : this.props.children;
+  }
+}

--- a/src/app/[locale]/preview/hero/hero-preview-client.tsx
+++ b/src/app/[locale]/preview/hero/hero-preview-client.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import {
+  useEffect,
+  useRef,
+  useState,
+  type MouseEvent as ReactMouseEvent,
+} from "react";
+import type { common_HeroFullWithTranslations } from "@/api/proto-http/frontend";
+
+import { Text } from "@/components/ui/text";
+import { HeroView } from "@/app/[locale]/_components/hero-view";
+
+import { HeroPreviewBoundary } from "./hero-preview-boundary";
+
+// Origins allowed to embed this iframe and push hero drafts into it. Keep in
+// sync with the `frame-ancestors` allowlist for /preview/* in next.config.ts.
+const ADMIN_ORIGINS = [
+  "https://admin.grbpwr.com",
+  "https://admin.beta.grbpwr.com",
+  "http://localhost:4040",
+];
+
+type HeroDraftMessage = {
+  type: "hero-draft";
+  hero: common_HeroFullWithTranslations;
+  rev: number;
+};
+
+export function HeroPreviewClient({
+  initialHero,
+}: {
+  initialHero: common_HeroFullWithTranslations | null;
+}) {
+  const [hero, setHero] = useState(initialHero);
+  // Latest applied revision. A ref (not state) so the listener can drop stale /
+  // out-of-order drafts without being torn down and re-subscribed each update.
+  const revRef = useRef(-1);
+
+  useEffect(() => {
+    function onMessage(e: MessageEvent) {
+      if (!ADMIN_ORIGINS.includes(e.origin)) return; // origin gate
+      const msg = e.data as Partial<HeroDraftMessage> | null;
+      if (!msg || msg.type !== "hero-draft" || !msg.hero) return;
+      // Keep only the newest draft — postMessage order isn't guaranteed.
+      if (typeof msg.rev === "number" && msg.rev <= revRef.current) return;
+      revRef.current = typeof msg.rev === "number" ? msg.rev : revRef.current;
+      setHero(msg.hero);
+    }
+
+    window.addEventListener("message", onMessage);
+    // Handshake: tell the editor the bridge is mounted so it replays the current
+    // draft immediately. Targeted origins only — never "*".
+    for (const origin of ADMIN_ORIGINS) {
+      window.parent?.postMessage({ type: "hero-preview-ready" }, origin);
+    }
+    return () => window.removeEventListener("message", onMessage);
+  }, []);
+
+  // Clicking a block should highlight it in the editor, not follow its explore
+  // link. Running in the capture phase (before the block's own Link/onClick) and
+  // calling preventDefault + stopPropagation suppresses both navigation and the
+  // hero analytics event; the parent gets the block's `data-hero-block-index`.
+  function onBlockClickCapture(e: ReactMouseEvent) {
+    const el = (e.target as HTMLElement | null)?.closest?.(
+      "[data-hero-block-index]",
+    );
+    if (!el) return;
+    const index = Number(el.getAttribute("data-hero-block-index"));
+    if (!Number.isFinite(index)) return;
+    e.preventDefault();
+    e.stopPropagation();
+    for (const origin of ADMIN_ORIGINS) {
+      window.parent?.postMessage({ type: "hero-block-click", index }, origin);
+    }
+  }
+
+  if (!hero) {
+    return (
+      <div className="flex min-h-dvh items-center justify-center bg-bgColor p-6">
+        <Text variant="uppercase">waiting for editor…</Text>
+      </div>
+    );
+  }
+
+  return (
+    <HeroPreviewBoundary
+      resetKey={hero}
+      fallback={
+        <div className="flex min-h-dvh items-center justify-center bg-bgColor p-6">
+          <Text variant="uppercase">
+            block render error — waiting for next draft…
+          </Text>
+        </div>
+      }
+    >
+      {/* display:contents = layout-neutral; the capture handler intercepts block
+          clicks before their Link navigates. */}
+      <div style={{ display: "contents" }} onClickCapture={onBlockClickCapture}>
+        <HeroView hero={hero} />
+      </div>
+    </HeroPreviewBoundary>
+  );
+}

--- a/src/app/[locale]/preview/hero/page.tsx
+++ b/src/app/[locale]/preview/hero/page.tsx
@@ -1,0 +1,24 @@
+import { setRequestLocale } from "next-intl/server";
+
+import { getHero } from "@/lib/api";
+
+import { HeroPreviewClient } from "./hero-preview-client";
+
+// The editor drives this iframe live over postMessage, so it must never be
+// statically cached or ISR-revalidated like the homepage — always render fresh.
+export const dynamic = "force-dynamic";
+
+export default async function HeroPreviewPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+
+  // First paint = the currently published hero, so the frame isn't blank before
+  // the editor posts its first draft. Tolerate a backend failure gracefully.
+  const initial = await getHero().catch(() => null);
+
+  return <HeroPreviewClient initialHero={initial?.hero ?? null} />;
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -30,6 +30,10 @@ export const SITE_DISABLED_ALLOWED_REST_PATHS: readonly string[] = [
   "/order",
   "/return",
   "/faq",
+  // Hero editor preview iframe: must stay reachable while the shop is toggled
+  // off (that's exactly when an editor is staging a new hero). Keeps both the
+  // middleware redirect and SiteGuard from bouncing /preview/* to home.
+  "/preview",
 ];
 
 export const CATALOG_LIMIT = 16;


### PR DESCRIPTION
Ports the `/preview/hero` hero-editor preview from beta (#648) onto master, **isolated to just the hero feature** (master already carries the security/CSP work as #631/#632/#633).

## What
A `/preview/hero` route renders the real storefront hero (`MainAds` + `Ads`) from an admin-editor draft over `postMessage` — faithful desktop+mobile preview, zero duplicated rendering.

- **HeroView** — shared pure render of the hero blocks (homepage + preview iframe).
- **Route + bridge** — origin-gated allowlist, monotonic `rev`, `hero-preview-ready` handshake, render error boundary; `/preview` exempt from the site-disabled redirect.
- **CSP** — `frame-ancestors` for `/preview/*` (admin origins), `X-Frame-Options` dropped there; every other path stays `'self'` + `SAMEORIGIN`; preview excluded from the global CSP block so exactly one CSP header is emitted.
- **hero-block-click** — clicking a block posts its entity index to the parent editor instead of navigating.

## Scope
8 files, +338/−67. Only the hero feature — the shared files (`ads.tsx`, `page.tsx`, `constants.ts`, `next.config.ts`) differ from master by **exactly** these changes (verified). Admin integration doc lives in `tmp/preview-hero-admin-integration.md`.

## Verification
`tsc --noEmit` clean, ESLint clean on master base; headless-Chrome postMessage-bridge harness 8/8 (ready, live-update, stale-rev, newer-rev, bad-origin, block-click posts index + no nav).

🤖 Generated with [Claude Code](https://claude.com/claude-code)