### PR TITLE
fix(hero): make URL locale authoritative for /preview/* (ignore NEXT_LOCALE cookie)

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -65,6 +65,13 @@ export default async function middleware(req: NextRequest) {
     if (parsedPath) {
         const { country, locale, rest } = parsedPath;
 
+        // The hero editor drives /preview/* inside an admin iframe and controls
+        // the language purely via the URL locale. Exempt it from the NEXT_LOCALE
+        // cookie override below (and from mutating the visitor's storefront
+        // cookies) so the URL locale — the only signal the editor sends — wins.
+        const isPreview =
+            rest === "/preview" || (rest?.startsWith("/preview/") ?? false);
+
         // Redirect to home when site is disabled and URL is not timeline / footer-help allowlist
         if (rest?.trim() && !isAllowedWhenSiteDisabled(pathname)) {
             try {
@@ -106,6 +113,7 @@ export default async function middleware(req: NextRequest) {
         // first, so they don't bounce. New visitors / crawlers (no cookie) get the
         // URL as-is and the cookie is synced below.
         if (
+            !isPreview &&
             localeCookie &&
             localeCookie !== locale &&
             (routing.locales as readonly string[]).includes(localeCookie)
@@ -183,6 +191,11 @@ export default async function middleware(req: NextRequest) {
             // third-party caches/proxies.
             res.headers.set("Cache-Control", "private, no-cache, must-revalidate");
         }
+        // Editor preview iframe: the URL locale is authoritative and we must not
+        // mutate the visitor's storefront NEXT_LOCALE/COUNTRY cookies. The rewrite
+        // already carries x-nextjs-locale + a URL-derived Cookie header for the RSC
+        // read, so the preview renders in the URL's language without persisting it.
+        if (isPreview) return res;
         setMainCookies(res, country!, locale!);
         const suggestCountryCookie = req.cookies.get("NEXT_SUGGEST_COUNTRY")?.value;
         const suggestLocaleCookie = req.cookies.get("NEXT_SUGGEST_LOCALE")?.value;


### PR DESCRIPTION
The hero editor embeds `/preview/hero` in an admin iframe and selects the preview language via the URL locale (`/{country}/{locale}/preview/hero`). But the storefront middleware intentionally lets a `NEXT_LOCALE` cookie override the URL locale (so a shopper's chosen language sticks) — and because `admin.grbpwr.com` and the storefront are the **same site**, that `SameSite=Lax` cookie reaches the iframe. So the preview rendered the admin's cookie language, not the URL's.

## Fix (middleware only, +13 lines, no contract change)
- Exempt `/preview/*` from the cookie language-preference override → the URL locale wins.
- Skip mutating the visitor's `NEXT_LOCALE`/`NEXT_COUNTRY` cookies from the editor iframe.

The locale is already carried by the iframe URL, so the postMessage contract is untouched.

## Verified
- `/gb/de/preview/hero` with `NEXT_LOCALE=en` → now `200`, `lang="de"`, no `Set-Cookie` (was `307 → /gb/en`).
- Normal `/gb/de` + `en` cookie → still `307 → /gb/en` (storefront language preference intact — no regression).
- postMessage bridge harness 8/8; `tsc` + ESLint clean.

`middleware.ts` is not prettier-managed (4-space indent), so it was intentionally not reformatted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)