### PR TITLE
fix(orders): friendly 400/429 handling for order/newsletter/notify endpoints

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -654,7 +654,8 @@
     "validation_error": "etwas ist schiefgelaufen. bitte versuchen sie es erneut.",
     "fill_required_fields": "einige pflichtfelder fehlen",
     "email_required": "e-mail ist erforderlich",
-    "required_terms": "zustimmung zum abonnieren erforderlich"
+    "required_terms": "zustimmung zum abonnieren erforderlich",
+    "too_many_requests": "zu viele versuche. bitte warten sie einen moment und versuchen sie es erneut."
   },
   "refund": {
     "return order": "bestellung retournieren",

--- a/messages/en.json
+++ b/messages/en.json
@@ -711,7 +711,8 @@
     "validation_error": "something went wrong. please try again.",
     "fill_required_fields": "some required fields are missing",
     "email_required": "email is required",
-    "required_terms": "consent required to subscribe"
+    "required_terms": "consent required to subscribe",
+    "too_many_requests": "too many attempts. please wait a moment and try again."
   },
   "refund": {
     "return order": "return order",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -653,7 +653,8 @@
     "validation_error": "une erreur s'est produite. veuillez réessayer.",
     "fill_required_fields": "certains champs obligatoires sont manquants",
     "email_required": "l'e-mail est obligatoire",
-    "required_terms": "consentement requis pour s'abonner"
+    "required_terms": "consentement requis pour s'abonner",
+    "too_many_requests": "trop de tentatives. veuillez patienter un instant et réessayer."
   },
   "refund": {
     "return order": "retourner la commande",

--- a/messages/it.json
+++ b/messages/it.json
@@ -653,7 +653,8 @@
     "validation_error": "qualcosa è andato storto. riprova.",
     "fill_required_fields": "alcuni campi obbligatori mancano",
     "email_required": "l'email è obbligatoria",
-    "required_terms": "consenso richiesto per l'iscrizione"
+    "required_terms": "consenso richiesto per l'iscrizione",
+    "too_many_requests": "troppi tentativi. attendi un momento e riprova."
   },
   "refund": {
     "return order": "restituisci ordine",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -653,7 +653,8 @@
     "validation_error": "問題が発生しました。もう一度お試しください。",
     "fill_required_fields": "必須項目が未入力です",
     "email_required": "メールアドレスは必須です",
-    "required_terms": "登録するには同意が必要です"
+    "required_terms": "登録するには同意が必要です",
+    "too_many_requests": "リクエストが多すぎます。しばらくしてからもう一度お試しください。"
   },
   "refund": {
     "return order": "注文返品",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -653,7 +653,8 @@
     "validation_error": "문제가 발생했습니다. 다시 시도해 주세요.",
     "fill_required_fields": "필수 항목이 입력되지 않았습니다",
     "email_required": "이메일은 필수입니다",
-    "required_terms": "구독하려면 동의가 필요합니다"
+    "required_terms": "구독하려면 동의가 필요합니다",
+    "too_many_requests": "시도가 너무 많습니다. 잠시 후 다시 시도해 주세요."
   },
   "refund": {
     "return order": "주문 반품",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -653,7 +653,8 @@
     "validation_error": "出了点问题。请重试。",
     "fill_required_fields": "部分必填字段尚未填写",
     "email_required": "邮箱为必填项",
-    "required_terms": "订阅需要同意"
+    "required_terms": "订阅需要同意",
+    "too_many_requests": "尝试次数过多。请稍后再试。"
   },
   "refund": {
     "return order": "退货订单",

--- a/src/app/[locale]/(content)/_components/order-status-form.tsx
+++ b/src/app/[locale]/(content)/_components/order-status-form.tsx
@@ -10,6 +10,7 @@ import { z } from "zod";
 
 import { sendFormEvent } from "@/lib/analitycs/form";
 import { serviceClient } from "@/lib/api";
+import { isRateLimitError } from "@/lib/error-message";
 import { useFixedWithinContainer } from "@/lib/hooks/useFixedWithinContainer";
 import { syncSignedInEmailToForm } from "@/lib/stores/account-onboarding/selectors";
 import { useAccountOnboardingStore } from "@/lib/stores/account-onboarding/store-provider";
@@ -32,6 +33,7 @@ type OrderStatusData = z.infer<typeof orderStatusSchema>;
 
 export default function OrderStatusForm() {
   const t = useTranslations("order-status");
+  const tToaster = useTranslations("toaster");
   const [isLoading, setIsLoading] = useState(false);
   const [open, setOpen] = useState(false);
   const [toastMessage, setToastMessage] = useState("");
@@ -77,10 +79,11 @@ export default function OrderStatusForm() {
       }
     } catch (error) {
       console.error(error);
-      const message =
-        error instanceof Error && error.message
-          ? error.message
-          : t("order not found");
+      // Never surface the raw server message; the 4 order endpoints share one
+      // rate-limit bucket (5 / 10 min / IP), so a burst can 429 a real order.
+      const message = isRateLimitError(error)
+        ? tToaster("too_many_requests")
+        : t("order not found");
       setToastMessage(message);
       setOpen(true);
     } finally {

--- a/src/app/[locale]/_components/newsletter-form/index.tsx
+++ b/src/app/[locale]/_components/newsletter-form/index.tsx
@@ -8,6 +8,7 @@ import { useForm, type UseFormReturn } from "react-hook-form";
 import { sendNewsletterSignupEvent } from "@/lib/analitycs/form";
 import { pushUserIdToDataLayer } from "@/lib/analitycs/utils";
 import { serviceClient } from "@/lib/api";
+import { isInvalidInputError, isRateLimitError } from "@/lib/error-message";
 import { syncSignedInEmailToForm } from "@/lib/stores/account-onboarding/selectors";
 import { useAccountOnboardingStore } from "@/lib/stores/account-onboarding/store-provider";
 import { Form } from "@/components/ui/form";
@@ -74,9 +75,10 @@ export default function NewslatterForm({
       setToastOpen(true);
     } catch (error) {
       console.error("Failed to subscribe to newsletter:", error);
-      const message =
-        error instanceof Error && error.message
-          ? error.message
+      const message = isRateLimitError(error)
+        ? tToaster("too_many_requests")
+        : isInvalidInputError(error)
+          ? tToaster("invalid_email")
           : tToaster("failed_to_subscribe");
       setToastMessage(message);
       setToastOpen(true);

--- a/src/app/[locale]/product/[...productParams]/_components/notify-me.tsx
+++ b/src/app/[locale]/product/[...productParams]/_components/notify-me.tsx
@@ -9,6 +9,7 @@ import { useForm } from "react-hook-form";
 
 import { sendNotifyMeIntentEvent } from "@/lib/analitycs/product-engagement";
 import { serviceClient } from "@/lib/api";
+import { isInvalidInputError, isRateLimitError } from "@/lib/error-message";
 import { useAccountOnboardingStore } from "@/lib/stores/account-onboarding/store-provider";
 import { Button } from "@/components/ui/button";
 import CheckboxGlobal from "@/components/ui/checkbox";
@@ -153,9 +154,10 @@ export function NotifyMe({
       setToastOpen(true);
     } catch (e) {
       console.error("Form submission failed:", e);
-      const message =
-        e instanceof Error && e.message
-          ? e.message
+      const message = isRateLimitError(e)
+        ? tToaster("too_many_requests")
+        : isInvalidInputError(e)
+          ? tToaster("invalid_email")
           : tToaster("failed_to_subscribe");
       setToastMessage(message);
       setToastOpen(true);
@@ -167,82 +169,82 @@ export function NotifyMe({
   return (
     <DialogPrimitives.Root open={open} onOpenChange={handleOpenChange}>
       <DialogPrimitives.Portal>
-        <DialogPrimitives.Overlay className="fixed inset-0 z-20 h-screen bg-overlay data-[state=open]:animate-modal-fade-in data-[state=closed]:animate-modal-fade-out" />
-        <DialogPrimitives.Content className="fixed inset-x-2.5 top-1/2 z-50 flex h-auto w-auto -translate-y-1/2 flex-col border border-textInactiveColor bg-bgColor p-2.5 text-textColor data-[state=open]:animate-modal-fade-in data-[state=closed]:animate-modal-fade-out lg:inset-x-auto lg:left-1/2 lg:w-80 lg:-translate-x-1/2">
-              <DialogPrimitives.Title className="sr-only">
-                {tAccessibility("notify me dialog")}
-              </DialogPrimitives.Title>
-              <Form {...form}>
-                <form
-                  onSubmit={form.handleSubmit(handleSubmit)}
-                  className="flex h-auto flex-col justify-between gap-10"
-                >
-                  <div className="flex items-center justify-between">
-                    <Text variant="uppercase">{tProduct("notify me")}</Text>
-                    <DialogPrimitives.Close asChild>
-                      <Button aria-label={tNav("close")}>[x]</Button>
-                    </DialogPrimitives.Close>
-                  </div>
-                  <div className="flex h-full flex-col justify-center space-y-10">
-                    <Text className="leading-none">
-                      {tProduct("notify-description")}
-                    </Text>
+        <DialogPrimitives.Overlay className="fixed inset-0 z-20 h-screen bg-overlay data-[state=closed]:animate-modal-fade-out data-[state=open]:animate-modal-fade-in" />
+        <DialogPrimitives.Content className="fixed inset-x-2.5 top-1/2 z-50 flex h-auto w-auto -translate-y-1/2 flex-col border border-textInactiveColor bg-bgColor p-2.5 text-textColor data-[state=closed]:animate-modal-fade-out data-[state=open]:animate-modal-fade-in lg:inset-x-auto lg:left-1/2 lg:w-80 lg:-translate-x-1/2">
+          <DialogPrimitives.Title className="sr-only">
+            {tAccessibility("notify me dialog")}
+          </DialogPrimitives.Title>
+          <Form {...form}>
+            <form
+              onSubmit={form.handleSubmit(handleSubmit)}
+              className="flex h-auto flex-col justify-between gap-10"
+            >
+              <div className="flex items-center justify-between">
+                <Text variant="uppercase">{tProduct("notify me")}</Text>
+                <DialogPrimitives.Close asChild>
+                  <Button aria-label={tNav("close")}>[x]</Button>
+                </DialogPrimitives.Close>
+              </div>
+              <div className="flex h-full flex-col justify-center space-y-10">
+                <Text className="leading-none">
+                  {tProduct("notify-description")}
+                </Text>
 
-                    <div className="space-y-16 lg:space-y-10">
-                      <div className="space-y-4">
-                        <Text>{tProduct("select size")}:</Text>
-                        <SizePicker
-                          sizeNames={outOfStockSizes}
-                          activeSizeId={selectedSizeId}
-                          handleSizeSelect={handleSizeSelect}
-                          view="grid"
-                        />
-                        {form.formState.errors.sizeId && (
-                          <Text className="text-errorColor">
-                            {form.formState.errors.sizeId.message}
-                          </Text>
-                        )}
-                      </div>
-                      <div className="space-y-4" data-nosnippet>
-                        <InputField
-                          name="email"
-                          label={t("email")}
-                          type="email"
-                          variant="secondary"
-                        />
-                        <CheckboxGlobal
-                          name="newsLetter"
-                          label={tProduct.rich("notify-agree", {
-                            privacy: (chunks) => (
-                              <Link
-                                href="/legal-notices?section=privacy"
-                                className="underline hover:no-underline"
-                              >
-                                {chunks}
-                              </Link>
-                            ),
-                          })}
-                          checked={isChecked}
-                          onCheckedChange={(checked: boolean) =>
-                            setIsChecked(checked)
-                          }
-                        />
-                      </div>
-                    </div>
+                <div className="space-y-16 lg:space-y-10">
+                  <div className="space-y-4">
+                    <Text>{tProduct("select size")}:</Text>
+                    <SizePicker
+                      sizeNames={outOfStockSizes}
+                      activeSizeId={selectedSizeId}
+                      handleSizeSelect={handleSizeSelect}
+                      view="grid"
+                    />
+                    {form.formState.errors.sizeId && (
+                      <Text className="text-errorColor">
+                        {form.formState.errors.sizeId.message}
+                      </Text>
+                    )}
                   </div>
+                  <div className="space-y-4" data-nosnippet>
+                    <InputField
+                      name="email"
+                      label={t("email")}
+                      type="email"
+                      variant="secondary"
+                    />
+                    <CheckboxGlobal
+                      name="newsLetter"
+                      label={tProduct.rich("notify-agree", {
+                        privacy: (chunks) => (
+                          <Link
+                            href="/legal-notices?section=privacy"
+                            className="underline hover:no-underline"
+                          >
+                            {chunks}
+                          </Link>
+                        ),
+                      })}
+                      checked={isChecked}
+                      onCheckedChange={(checked: boolean) =>
+                        setIsChecked(checked)
+                      }
+                    />
+                  </div>
+                </div>
+              </div>
 
-                  <Button
-                    variant="main"
-                    type="submit"
-                    size="lg"
-                    className="w-full uppercase transition-opacity active:opacity-70"
-                    disabled={form.formState.isSubmitting || isLoading}
-                    loading={isLoading}
-                  >
-                    {tProduct("notify me")}
-                  </Button>
-                </form>
-              </Form>
+              <Button
+                variant="main"
+                type="submit"
+                size="lg"
+                className="w-full uppercase transition-opacity active:opacity-70"
+                disabled={form.formState.isSubmitting || isLoading}
+                loading={isLoading}
+              >
+                {tProduct("notify me")}
+              </Button>
+            </form>
+          </Form>
         </DialogPrimitives.Content>
       </DialogPrimitives.Portal>
       <SubmissionToaster

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,7 +1,10 @@
 import { cache } from "react";
-
 import { createFrontendServiceClient } from "@/api/proto-http/frontend";
-import { ARCHIVES_CACHE_TAG, HERO_CACHE_TAG, PRODUCTS_CACHE_TAG } from "@/constants";
+import {
+  ARCHIVES_CACHE_TAG,
+  HERO_CACHE_TAG,
+  PRODUCTS_CACHE_TAG,
+} from "@/constants";
 
 type Object = {
   [key: string]: unknown;
@@ -50,7 +53,6 @@ const requestHandler = async (
   { path, method, body }: RequestHandlerParams,
   { method: serviceMethod }: ProtoMetaParams,
 ) => {
-
   const response = await fetch(
     `${process.env.NEXT_PUBLIC_BACKEND_URL}/${path}`,
     {
@@ -60,14 +62,27 @@ const requestHandler = async (
     },
   );
 
-  const data = await response.json();
+  // Read the body as text first so a non-JSON error payload (e.g. a bare 429
+  // from a rate-limiter/proxy) can't throw a parse error that masks the real
+  // HTTP status — callers rely on being able to detect 429/400.
+  const text = await response.text();
+  let data: { message?: string; code?: number; [key: string]: unknown } | null =
+    null;
+  if (text) {
+    try {
+      data = JSON.parse(text);
+    } catch {
+      data = null;
+    }
+  }
 
   if (!response.ok) {
     const error = new Error(
-      (data?.message as string) || response.statusText || "Request failed",
-    ) as Error & { code?: number; details?: unknown };
-    error.code = data?.code;
-    error.details = data;
+      data?.message || response.statusText || "Request failed",
+    ) as Error & { code?: number; status?: number; details?: unknown };
+    error.code = data?.code; // gRPC code (3 = InvalidArgument, 8 = ResourceExhausted)
+    error.status = response.status; // HTTP status (400, 429, …)
+    error.details = data ?? text;
     throw error;
   }
 

--- a/src/lib/error-message.ts
+++ b/src/lib/error-message.ts
@@ -1,3 +1,20 @@
 export function getErrorMessage(error: unknown, fallback: string): string {
   return error instanceof Error && error.message ? error.message : fallback;
 }
+
+// Errors thrown by the API client (see src/lib/api.ts) carry the HTTP `status`
+// and the gRPC `code` from the gateway. These map the two the storefront cares
+// about so callers can show localized copy instead of the raw server message.
+type ApiError = { status?: number; code?: number };
+
+// HTTP 429 / gRPC ResourceExhausted (8) — rate limit hit.
+export function isRateLimitError(error: unknown): boolean {
+  const e = error as ApiError | null;
+  return e?.status === 429 || e?.code === 8;
+}
+
+// HTTP 400 / gRPC InvalidArgument (3) — bad input (e.g. malformed email).
+export function isInvalidInputError(error: unknown): boolean {
+  const e = error as ApiError | null;
+  return e?.status === 400 || e?.code === 3;
+}


### PR DESCRIPTION
## What

Backend-audit integration — friendly 400/429 handling for newsletter, notify-me, and order lookups.

> The analytics/PII commit from this line (`fa79b539`) is **already on `beta`**, so this PR is just the backend-audit change (`e3a24d68`).

The backend audit (`fix/backend-audit`) put the four order RPCs on **one shared rate-limit bucket (5 req / 10 min / IP)** and now returns `InvalidArgument` (400) / `ResourceExhausted` (429). This surfaces localized copy instead of the raw server message.

- **`src/lib/api.ts`** — defensive error-body parse; attach HTTP `status` + gRPC `code` to thrown errors.
- **`src/lib/error-message.ts`** — `isRateLimitError` / `isInvalidInputError`.
- **Newsletter + Notify-me** — 429 → `too_many_requests`, 400 → `invalid_email`.
- **Order-status form** — 429 → friendly copy; no raw server text.
- **`messages/*`** — `toaster.too_many_requests` in all 7 locales.

No proto/client regen (contracts unchanged).

## Verification

- `tsc --noEmit` clean; `pnpm lint` clean (pre-existing warnings only); all 7 locale JSONs valid; Prettier applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
